### PR TITLE
DPAD-34 | Add heartbeat tracking

### DIFF
--- a/src/players/shared/addBaseTrackingEvents.ts
+++ b/src/players/shared/addBaseTrackingEvents.ts
@@ -65,7 +65,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 			}
 
 			// 10s interval events firing
-			if (event.position < 60) {
+			if (event.position < 60 && event.position >= 10) {
 				const tenSecondBucket = Math.floor(event.position / 10);
 
 				if (singleTrack(`jw-player-heartbeat-second-${mediaId}-${tenSecondBucket}`)) {

--- a/src/players/shared/addBaseTrackingEvents.ts
+++ b/src/players/shared/addBaseTrackingEvents.ts
@@ -39,7 +39,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 			if (singleTrack(initialPlayEvent)) {
 				const timeToFirstFrame = recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_VIDEO);
 				jwPlayerPlaybackTracker({
-					event: 'video_content_start',
+					event_name: 'video_content_start',
 					video_time_to_first_frame: timeToFirstFrame,
 					video_startup_time: getVideoStartupTime(),
 				});
@@ -62,6 +62,29 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				jwPlayerContentTracker({
 					event_name: 'video_content_quartile_75',
 				});
+			}
+
+			// 10s interval events firing
+			if (event.position < 60) {
+				const tenSecondBucket = Math.floor(event.position / 10);
+
+				if (singleTrack(`jw-player-heartbeat-second-${mediaId}-${tenSecondBucket}`)) {
+					jwPlayerContentTracker({
+						event_name: 'video_content_playing',
+						video_content_seconds_viewed: 10,
+					});
+				}
+			}
+
+			if (event.position > 60) {
+				const minuteBucket = Math.floor(event.position / 60);
+
+				if (singleTrack(`jw-player-heartbeat-min-${mediaId}-${minuteBucket}`)) {
+					jwPlayerContentTracker({
+						event_name: 'video_content_playing',
+						video_content_seconds_viewed: 60,
+					});
+				}
 			}
 		})
 		.on(JWEvents.COMPLETE, () => {
@@ -176,6 +199,29 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				jwPlayerAdTracker({
 					event_name: 'video_ad_quartile_75',
 				});
+			}
+
+			// 10s interval events firing
+			if (event.position < 10) {
+				const oneSecondBucket = Math.floor(event.position);
+
+				if (singleTrack(`jw-player-ad-heartbeat-second-${mediaId}-${oneSecondBucket}`)) {
+					jwPlayerContentTracker({
+						event_name: 'video_ad_playing',
+						video_ad_seconds_viewed: 1,
+					});
+				}
+			}
+
+			if (event.position > 10) {
+				const tenSecondBucket = Math.floor(event.position / 10);
+
+				if (singleTrack(`jw-player-ad-heartbeat-min-${mediaId}-${tenSecondBucket}`)) {
+					jwPlayerContentTracker({
+						event_name: 'video_ad_playing',
+						video_ad_seconds_viewed: 10,
+					});
+				}
 			}
 		});
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -117,6 +117,13 @@ interface Plugins {
 	sharing: BasePluginInterface;
 }
 
+interface QualityObject {
+	bitrate: number;
+	label: string;
+	width: number;
+	height: number;
+}
+
 export type Player = {
 	playToggle: () => null;
 	pause: () => null;
@@ -143,6 +150,7 @@ export type Player = {
 	getFullscreen: () => boolean;
 	getFloating: () => boolean;
 	plugins: Plugins;
+	getQualityLevels: () => QualityObject[];
 };
 export type CreateWirewaxEmbedder = () => Embedder;
 export type WirewaxPluginOptions = {

--- a/src/utils/globalJWInterface.ts
+++ b/src/utils/globalJWInterface.ts
@@ -103,3 +103,24 @@ export const getJWViewState = withTryCatchDefault(() => {
 
 	return 'standard';
 });
+
+// TODO Current not possible
+export const getIsEmbed = withTryCatchDefault(() => {
+	return false;
+});
+
+export const getJWQualityManifest = withTryCatchDefault(() => {
+	return window
+		.jwplayer()
+		.getQualityLevels()
+		.map((obj) => obj.label)
+		.join(',');
+});
+
+// It reads to me like we'd generate that ourselves each time a new video is played, to tie together all the other events.' +
+// ' Something like a hash that wouldn't need to be related to anything, just as long as all events for that CURRENT video have
+// that dimension applied.
+export const getUniqueStreamId = withTryCatchDefault(() => {
+	// this should b
+	return window;
+});

--- a/src/utils/videoTracking.ts
+++ b/src/utils/videoTracking.ts
@@ -15,6 +15,8 @@ import {
 	getIsInteractable,
 	getJWAdBlockState,
 	getJWViewState,
+	getIsEmbed,
+	getJWQualityManifest,
 } from 'utils/globalJWInterface';
 import addGlobalProps from 'utils/videoTrackingGlobalProps';
 import getVideoPlayerVersion from 'utils/getVideoPlayerVersion';
@@ -92,6 +94,8 @@ function addRunTimeParams(trackingParams: TrackData): TrackData {
 	trackDataObject[PROPERTY_NAMES.VIDEO_DURATION] = getDuration();
 	trackDataObject[PROPERTY_NAMES.VIDEO_PLAYER] = getPlayerId();
 	trackDataObject[PROPERTY_NAMES.VIDEO_VIEW_STATE] = getJWViewState();
+	trackDataObject[PROPERTY_NAMES.VIDEO_IS_EMBEDDED] = getIsEmbed();
+	trackDataObject[PROPERTY_NAMES.VIDEO_QUALITY_MANIFEST] = getJWQualityManifest();
 
 	// TO BE ADDED LATER
 	// trackDataObject[PROPERTY_NAMES.VIDEO_COLLECTION] = getCollection();

--- a/src/utils/videoTrackingGlobalProps.ts
+++ b/src/utils/videoTrackingGlobalProps.ts
@@ -60,6 +60,9 @@ export default function addGlobalProps(): TrackData {
 		defaultProps[GLOBAL_PROPS.BEACON_ID] = getCookieValue('wikia_beacon_id');
 		defaultProps[GLOBAL_PROPS.BEACON_ID2] = getCookieValue('_b2');
 
+		// Set sane defaults
+		defaultProps[GLOBAL_PROPS.SKIN] = 'unknown';
+
 		// If we are on MW lets add them this way
 		if (window && window.mw && window.mw.config) {
 			defaultProps = { ...defaultProps, ...getDefaultsFromMWConfig() };


### PR DESCRIPTION
* Fires events for ads at one second intervals for first ten seconds then one per ten seconds
* Fires event for content at 10 seconds intervals until the first minute than at one minute intervals