### PR TITLE
DPAD-263 :: Temporarily move the setting of JWPlayer version in window object to React component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-2",
+	"version": "2.0.0-beta-4",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/src/hooks/usePlayerVersion.tsx
+++ b/src/hooks/usePlayerVersion.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import getVideoPlayerVersion from 'utils/getVideoPlayerVersion';
+
+/* Temporarily use this hook to set the JWPlayer version, instead of setting it
+ * in the main.ts file. The reason behind this is due to issues in UCP,
+ * where both versions of the old and this new player are loaded, and the main.ts
+ * file always executes. This will be reverted back in the future to be set in the main.ts file. */
+const usePlayerVersion = () => {
+	useEffect(() => {
+		if (window) {
+			console.debug('JWPlayer version set.');
+			const playerVersion = getVideoPlayerVersion();
+			/* eslint-disable */
+			// @ts-ignore
+			window.__fandom_jw_player_version = playerVersion;
+			/* eslint-enable */
+		} else {
+			console.debug('Cannot set __fandom_jw_player_version on the server-side');
+		}
+	}, []);
+};
+
+export default usePlayerVersion;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,10 @@ export * from './players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer';
 export { default as MobileArticleVideoPlayer } from './players/MobileArticleVideoPlayer/MobileArticleVideoPlayer';
 export * from './players/MobileArticleVideoPlayer/MobileArticleVideoPlayer';
 
+/*
 // @ts-ignore
 window.__fandom_jw_player_version = process.env.VIDEO_VERSION;
+*/
 export function getVideoPlayerVersion() {
 	return process.env.VIDEO_VERSION;
 }

--- a/src/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -10,6 +10,7 @@ import PlayerWrapper from 'players/shared/PlayerWrapper';
 import { Playlist } from 'types';
 import CloseButton from 'players/shared/CloseButton';
 import Attribution from 'players/DesktopArticleVideoPlayer/Attribution';
+import usePlayerVersion from 'hooks/usePlayerVersion';
 
 const DesktopArticleVideoTopPlaceholder = styled.div`
 	background-color: black;
@@ -48,6 +49,7 @@ interface DesktopArticleVideoPlayerProps {
 }
 
 const DesktopArticleVideoPlayer: React.FC<DesktopArticleVideoPlayerProps> = ({ playlist }) => {
+	usePlayerVersion();
 	const ref = useRef<HTMLDivElement>(null);
 	const adComplete = useAdComplete();
 	const onScreen = useOnScreen(ref);

--- a/src/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -10,6 +10,7 @@ import { Playlist } from 'types';
 import Attribution from 'players/MobileArticleVideoPlayer/Attribution';
 import { singleTrack } from 'utils/videoTracking';
 import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'utils/videoTimingEvents';
+import usePlayerVersion from 'hooks/usePlayerVersion';
 
 const MobileArticleVideoTopPlaceholder = styled.div`
 	background-color: black;
@@ -45,6 +46,7 @@ const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
 	hasPartnerSlot,
 	isFullScreen,
 }) => {
+	usePlayerVersion();
 	const ref = useRef<HTMLDivElement>(null);
 	const adComplete = useAdComplete();
 	const onScreen = useOnScreen(ref);

--- a/src/players/VideoPlayer.tsx
+++ b/src/players/VideoPlayer.tsx
@@ -2,8 +2,10 @@ import React, { useRef } from 'react';
 import { VideoPlayerProps } from 'types';
 import PlayerWrapper from 'players/shared/PlayerWrapper';
 import JwPlayerWrapper from 'players/shared/JwPlayerWrapper';
+import usePlayerVersion from 'hooks/usePlayerVersion';
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({ playlist }) => {
+	usePlayerVersion();
 	const ref = useRef<HTMLDivElement>(null);
 
 	return (


### PR DESCRIPTION
The setting of `window.__fandom_jw_player_version` is temporarily being moved to each of the VideoPlayer components, and set through a hook on the initial component render. 

This is not the ideal solution at the moment, since it requires using the hook in each of the VideoPlayer components, but it does solve an issue in UCP. The main.ts script is loaded into the DOM, and causes the player version to be set in the window object, even though the new video player doesn't even load.

Bumped the jwplayer version from "version": "2.0.0-beta-2" to "version": "2.0.0-beta-4", since version 3 was already deployed to artifactory.