### PR TITLE
DPAD-262 | QA bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-2",
+	"version": "2.0.0-beta-3",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/src/players/shared/JWEvents.ts
+++ b/src/players/shared/JWEvents.ts
@@ -10,6 +10,7 @@ const JWEvents = {
 	SEEK: 'seek',
 	COMPLETE: 'complete',
 	TIME: 'time',
+	VIEWABLE: 'viewable',
 
 	// Navigation
 	NEXT: 'nextClick',

--- a/src/players/shared/addBaseTrackingEvents.ts
+++ b/src/players/shared/addBaseTrackingEvents.ts
@@ -10,6 +10,7 @@ import {
 	Player,
 	PlayPlayerEventData,
 	SeekEventData,
+	ShareEventData,
 } from 'types';
 import JWEvents from 'players/shared/JWEvents';
 import { jwPlayerPlaybackTracker, jwPlayerAdTracker, jwPlayerContentTracker, singleTrack } from 'utils/videoTracking';
@@ -151,6 +152,12 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 			});
 		})
 
+		.on(JWEvents.VIEWABLE, () => {
+			jwPlayerPlaybackTracker({
+				event_name: 'video_player_viewability_state',
+			});
+		})
+
 		.on(JWEvents.FULLSCREEN, (event: FullScreenEventData) => {
 			jwPlayerPlaybackTracker({
 				event_name: 'video_fullscreen_toggle',
@@ -257,10 +264,10 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 
 	// Safety check for sharing plugin
 	if (playerInstance.plugins && playerInstance.plugins.sharing && playerInstance.plugins.sharing.on) {
-		playerInstance.plugins.sharing.on('click', (method) => {
+		playerInstance.plugins.sharing.on('click', (method: ShareEventData) => {
 			jwPlayerPlaybackTracker({
 				event_name: 'video_share',
-				video_share_method: method,
+				video_share_method: method.method.toString(),
 			});
 		});
 	} else {

--- a/src/players/shared/addBaseTrackingEvents.ts
+++ b/src/players/shared/addBaseTrackingEvents.ts
@@ -14,6 +14,7 @@ import {
 import JWEvents from 'players/shared/JWEvents';
 import { jwPlayerPlaybackTracker, jwPlayerAdTracker, jwPlayerContentTracker, singleTrack } from 'utils/videoTracking';
 import { getVideoStartupTime, recordVideoEvent, VIDEO_RECORD_EVENTS } from 'utils/videoTimingEvents';
+import { getAssetId } from 'utils/globalJWInterface';
 
 function getAdPropsFromAdEvent(event: AdEvents) {
 	return {
@@ -27,9 +28,6 @@ function getAdPropsFromAdEvent(event: AdEvents) {
 }
 
 export default function addBaseTrackingEvents(playerInstance: Player) {
-	const playList = playerInstance.getPlaylistItem();
-	const mediaId = playList.mediaid;
-
 	// Add events
 	playerInstance
 		.on(JWEvents.PLAY, (event: PlayPlayerEventData) => {
@@ -59,6 +57,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 			}
 		})
 		.on(JWEvents.TIME, (event: OnVideoTimeEventData) => {
+			const mediaId = getAssetId();
 			if (event.position >= event.duration * 0.25 && singleTrack('jw-player-video-25' + mediaId)) {
 				jwPlayerContentTracker({
 					event_name: 'video_content_quartile_25',
@@ -205,6 +204,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 			});
 		})
 		.on(JWEvents.AD_TIME, (event: OnAdTimeEventData) => {
+			const mediaId = getAssetId();
 			console.log('ad_time', event);
 			const additionalAdProps = getAdPropsFromAdEvent(event);
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -109,6 +109,10 @@ export interface SeekEventData {
 	type: string;
 }
 
+export interface ShareEventData {
+	method: string;
+}
+
 type JwEventData =
 	| PlayPlayerEventData
 	| PausePlayerEventData
@@ -122,11 +126,12 @@ type JwEventData =
 	| FullScreenEventData
 	| SeekEventData
 	| AdEvents
-	| OnAdTimeEventData;
+	| OnAdTimeEventData
+	| ShareEventData;
 type JwEventHandler = (event?: JwEventData) => void;
 
 interface BasePluginInterface {
-	on: (name: string, handler: JwEventHandler) => Player;
+	on: (name: string, handler: (method: JwEventData) => void) => Player;
 }
 
 interface Plugins {

--- a/src/utils/globalJWInterface.ts
+++ b/src/utils/globalJWInterface.ts
@@ -38,6 +38,10 @@ export const getPlayListId = withTryCatchDefault(() => {
 });
 
 export const getVideoVolume = withTryCatchDefault(() => {
+	if (window.jwplayer().getMute()) {
+		return 0;
+	}
+
 	return window.jwplayer().getVolume();
 });
 
@@ -64,7 +68,7 @@ export const getDuration = withTryCatchDefault(() => {
 });
 
 export const getPlayerId = withTryCatchDefault(() => {
-	return window.jwplayer().getConfig().pid;
+	return 'jw-' + window.jwplayer().getConfig().pid;
 });
 
 export const getAssetTitle = withTryCatchDefault(() => {
@@ -76,7 +80,7 @@ export const getAssetId = withTryCatchDefault(() => {
 });
 
 export const getPublishDate = withTryCatchDefault(() => {
-	window.jwplayer().getPlaylistItem().pubdate;
+	return window.jwplayer().getPlaylistItem().pubdate;
 });
 
 export const getIsInteractable = withTryCatchDefault(() => {


### PR DESCRIPTION
* Fix publish date
* Fix mute on volume level
* Append 'jw-' to the video player name
* Add viewability event
* Fix media id for content playing events (required to move the mediaId into the event functions so they trigger at runtime

Remaining Issues: 
* PIP - The events are not properly firing as they should from the JW player API
* video_resume has some additional events that get fired on seek and select next