### PR TITLE
Adding timings for DPAD-391

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-10-391-1",
+	"version": "2.0.0-beta-11",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-10",
+	"version": "dpad-391-1",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "dpad-391-1",
+	"version": "2.0.0-beta-10-391-1",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/src/utils/articleVideo/articlePlayerOnReady.ts
+++ b/src/utils/articleVideo/articlePlayerOnReady.ts
@@ -1,6 +1,7 @@
 import { communicationService } from 'utils/communication';
 import { setVideoSeenInSession } from 'utils/articleVideo/articleVideoSession';
 import { willAutoplay, willMute } from 'utils/articleVideo/articleVideoConfig';
+import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'utils/videoTimingEvents';
 
 export default function useOnArticlePlayerReady(videoDetails, playerInstance): void {
 	const playerKey = 'aeJWPlayerKey';
@@ -11,6 +12,8 @@ export default function useOnArticlePlayerReady(videoDetails, playerInstance): v
 
 	window.dispatchEvent(new CustomEvent('wikia.jwplayer.instanceReady', { detail: playerInstance }));
 	window[playerKey] = playerInstance;
+
+	recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_PLAYER_READY_DISPATCH);
 
 	communicationService.dispatch({
 		type: '[JWPlayer] Player Ready',
@@ -27,12 +30,4 @@ export default function useOnArticlePlayerReady(videoDetails, playerInstance): v
 			videoId: videoDetails.playlist[0].mediaid,
 		},
 	});
-
-	// player.on('autoplayToggle', function (data) {
-	//     articleVideoCookieService.setAutoplay(data.enabled ? '1' : '0');
-	// });
-
-	// player.on('captionsSelected', function (data) {
-	//     articleVideoCookieService.setCaptions(data.selectedLang);
-	// });
 }

--- a/src/utils/useAdComplete.ts
+++ b/src/utils/useAdComplete.ts
@@ -3,14 +3,21 @@ import { useState, useEffect } from 'react';
 import { communicationService, ofType } from 'utils/communication';
 import { race, timer } from 'rxjs';
 import { first } from 'rxjs/operators';
+import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'utils/videoTimingEvents';
 
 export default function useAdComplete(): boolean {
 	const [adComplete, setAdComplete] = useState(false);
 
 	useEffect(() => {
+		recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START);
 		communicationService.action$.pipe(ofType('[AdEngine OptIn] set opt in'), first()).subscribe(() => {
+			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_OPT_IN_MESSAGE_RECIEVED);
+			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_CONFIG_LISTEN_START);
 			waitForAdEngine().then(() => {
+				recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_CONFIG_MESSAGE_RECIEVED);
+				recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_SETUP_JW_LISTEN_START);
 				listenSetupJWPlayer(function () {
+					recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_SETUP_JW_MESSAGE_RECIEVED);
 					setAdComplete(true);
 				});
 			});

--- a/src/utils/videoTimingEvents.ts
+++ b/src/utils/videoTimingEvents.ts
@@ -10,6 +10,13 @@ export const VIDEO_RECORD_EVENTS = {
 	JW_PLAYER_READY: PREFIX + 'ready',
 	JW_PLAYER_PLAYING_AD: PREFIX + 'playing-ad',
 	JW_PLAYER_PLAYING_VIDEO: PREFIX + 'playing-initial-video',
+	JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START: PREFIX + 'ad-eng-opt-in-isten-start',
+	JW_PLAYER_AD_ENG_OPT_IN_MESSAGE_RECIEVED: PREFIX + 'ad-eng-opt-in-message-recieved',
+	JW_PLAYER_AD_ENG_CONFIG_LISTEN_START: PREFIX + 'ad-eng-config-listen-start',
+	JW_PLAYER_AD_ENG_CONFIG_MESSAGE_RECIEVED: PREFIX + 'ad-eng-config-message-recieved',
+	JW_PLAYER_AD_ENG_SETUP_JW_LISTEN_START: PREFIX + 'ad-eng-setup-jw-listen-start',
+	JW_PLAYER_AD_ENG_SETUP_JW_MESSAGE_RECIEVED: PREFIX + 'ad-eng-setup-jw-message-recieved',
+	JW_PLAYER_AD_ENG_PLAYER_READY_DISPATCH: PREFIX + 'ad-eng-player-ready-dispatch',
 };
 
 const recordOptions = { sampleRate: 0.3 };

--- a/src/utils/videoTimingEvents.ts
+++ b/src/utils/videoTimingEvents.ts
@@ -10,7 +10,7 @@ export const VIDEO_RECORD_EVENTS = {
 	JW_PLAYER_READY: PREFIX + 'ready',
 	JW_PLAYER_PLAYING_AD: PREFIX + 'playing-ad',
 	JW_PLAYER_PLAYING_VIDEO: PREFIX + 'playing-initial-video',
-	JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START: PREFIX + 'ad-eng-opt-in-isten-start',
+	JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START: PREFIX + 'ad-eng-opt-in-listen-start',
 	JW_PLAYER_AD_ENG_OPT_IN_MESSAGE_RECIEVED: PREFIX + 'ad-eng-opt-in-message-recieved',
 	JW_PLAYER_AD_ENG_CONFIG_LISTEN_START: PREFIX + 'ad-eng-config-listen-start',
 	JW_PLAYER_AD_ENG_CONFIG_MESSAGE_RECIEVED: PREFIX + 'ad-eng-config-message-recieved',


### PR DESCRIPTION
https://fandom.atlassian.net/browse/DPAD-391
	
 New timing events present:
	'jw-player-ad-eng-opt-in-listen-start'
	'jw-player-ad-eng-opt-in-message-recieved'
	'jw-player-ad-eng-config-listen-start'
	'jw-player-ad-eng-config-message-recieved'
	'jw-player-ad-eng-setup-jw-listen-start'
	'jw-player-ad-eng-setup-jw-message-recieved'
	'jw-player-ad-eng-player-ready-dispatch'