### PR TITLE
DPAD-1030 :: Added class names to the mobile player elements to fix ToC overlap issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-18",
+	"version": "2.0.0-beta-21",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-17",
+	"version": "2.0.0-beta-18",
 	"description": "JWPlayer for Fandom",
 	"main": "bundle.umd.js",
 	"module": "bundle.esm.js",

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -99,7 +99,12 @@ const DesktopArticleVideoPlayer: React.FC<DesktopArticleVideoPlayerProps> = ({ v
 		<PlayerWrapper playerName="jw-desktop-article-video">
 			<DesktopArticleVideoTopPlaceholder ref={placeholderRef}>
 				{adComplete && (
-					<DesktopArticleVideoWrapper right={right} width={width} isScrollPlayer={isScrollPlayer}>
+					<DesktopArticleVideoWrapper
+						className={'desktop-article-video-wrapper'}
+						right={right}
+						width={width}
+						isScrollPlayer={isScrollPlayer}
+					>
 						<TopBar>
 							{!isScrollPlayer && <UnmuteButton />}
 							{isScrollPlayer && <CloseButton dismiss={() => setDismissed(true)} />}

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -90,7 +90,7 @@ const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
 
 	return (
 		<PlayerWrapper playerName="jw-mobile-article-video">
-			<MobileArticleVideoTopPlaceholder ref={ref}>
+			<MobileArticleVideoTopPlaceholder className={isScrollPlayer ? ' is-on-scroll-active ' : ''} ref={ref}>
 				{adComplete && (
 					<MobileArticleVideoWrapper isScrollPlayer={isScrollPlayer} topPosition={getTopPosition()}>
 						<JwPlayerWrapper

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -92,7 +92,11 @@ const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
 		<PlayerWrapper playerName="jw-mobile-article-video">
 			<MobileArticleVideoTopPlaceholder className={isScrollPlayer ? ' is-on-scroll-active ' : ''} ref={ref}>
 				{adComplete && (
-					<MobileArticleVideoWrapper isScrollPlayer={isScrollPlayer} topPosition={getTopPosition()}>
+					<MobileArticleVideoWrapper
+						className={'mobile-article-video-wrapper'}
+						isScrollPlayer={isScrollPlayer}
+						topPosition={getTopPosition()}
+					>
 						<JwPlayerWrapper
 							config={getArticleVideoConfig(videoDetails)}
 							onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}

--- a/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/OffScreenOverlay.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/OffScreenOverlay.tsx
@@ -35,7 +35,7 @@ const OffScreenOverlay: React.FC<OffScreenOverlayProps> = ({ dismiss }) => {
 	}
 
 	return (
-		<OffScreenOverlayWrapper playing={playing}>
+		<OffScreenOverlayWrapper className={'article-featured-video__on-scroll-video-wrapper'} playing={playing}>
 			<CloseButton dismiss={dismiss} />
 			<VideoDetails playing={playing} />
 		</OffScreenOverlayWrapper>


### PR DESCRIPTION
* Added class names to the mobile player elements to fix ToC overlap issue
* The code in UCP responsible for shifting the ToC based on certain class names is found in the following two places:
* https://github.com/Wikia/unified-platform/blob/bb5a7385fd77c1da778a45e24480848bc35f56f0/skins/FandomMobile/scripts/TableOfContents.ts#L35
* https://github.com/Wikia/unified-platform/blob/bb5a7385fd77c1da778a45e24480848bc35f56f0/skins/FandomMobile/scripts/TableOfContents.ts#L64
* There is still a small issue with the ToC element overlapping the right side of the bottom title bar, but this PR addresses the main issue of the ToC overlapping the close button
* Added classnames on certain video player elements, so that regression tests can target them easily