### PR TITLE
DPAD-1068 :: Move Close button down on Mobile Ad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-24",
+	"version": "2.0.0-beta-24-test-adbar-overlap-13",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-24-test-adbar-overlap-13",
+	"version": "2.0.0-beta-25",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -101,7 +101,7 @@ const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
 							config={getArticleVideoConfig(videoDetails)}
 							onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
 						/>
-						{isScrollPlayer && <OffScreenOverlay dismiss={() => setDismissed(true)} />}
+						<OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />
 					</MobileArticleVideoWrapper>
 				)}
 			</MobileArticleVideoTopPlaceholder>

--- a/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/OffScreenOverlay.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/OffScreenOverlay.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import VideoDetails from 'jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/VideoDetails';
 import CloseButton from 'jwplayer/players/shared/CloseButton';
 import WDSVariables from '@fandom-frontend/design-system/dist/variables.json';
+import useAdBreak from 'utils/useAdBreak';
 
 interface OffScreenOverlayWrapperProps {
 	playing: boolean;
@@ -22,11 +23,24 @@ const OffScreenOverlayWrapper = styled.div<OffScreenOverlayWrapperProps>`
 
 interface OffScreenOverlayProps {
 	dismiss: () => void;
+	isScrollPlayer: boolean;
 }
 
-const OffScreenOverlay: React.FC<OffScreenOverlayProps> = ({ dismiss }) => {
+const OffScreenOverlay: React.FC<OffScreenOverlayProps> = ({ dismiss, isScrollPlayer }) => {
 	const playing = usePlaying();
+	const adBreak = useAdBreak();
+	console.log('AdBreak Value: ', adBreak);
+
 	const controlbar = document.querySelector<HTMLElement>('.jw-controlbar');
+	let closeButtonOffset = 0;
+
+	if (adBreak) {
+		console.log('Ad should be playing. Adding 40px offset.');
+		closeButtonOffset = 40;
+	} else {
+		console.log("Ad should've finished. Setting top offset to 0px.");
+		closeButtonOffset = 0;
+	}
 
 	if (!playing) {
 		if (controlbar) controlbar.style.visibility = 'hidden';
@@ -34,9 +48,11 @@ const OffScreenOverlay: React.FC<OffScreenOverlayProps> = ({ dismiss }) => {
 		if (controlbar) controlbar.style.visibility = 'visible';
 	}
 
+	if (!isScrollPlayer) return null;
+
 	return (
 		<OffScreenOverlayWrapper className={'article-featured-video__on-scroll-video-wrapper'} playing={playing}>
-			<CloseButton dismiss={dismiss} />
+			<CloseButton topOffset={closeButtonOffset} dismiss={dismiss} />
 			<VideoDetails playing={playing} />
 		</OffScreenOverlayWrapper>
 	);

--- a/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/OffScreenOverlay.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/OffScreenOverlay.tsx
@@ -29,16 +29,15 @@ interface OffScreenOverlayProps {
 const OffScreenOverlay: React.FC<OffScreenOverlayProps> = ({ dismiss, isScrollPlayer }) => {
 	const playing = usePlaying();
 	const adBreak = useAdBreak();
-	console.log('AdBreak Value: ', adBreak);
 
 	const controlbar = document.querySelector<HTMLElement>('.jw-controlbar');
 	let closeButtonOffset = 0;
 
 	if (adBreak) {
-		console.log('Ad should be playing. Adding 40px offset.');
+		console.debug('Ad should be playing. Adding 40px offset.');
 		closeButtonOffset = 40;
 	} else {
-		console.log("Ad should've finished. Setting top offset to 0px.");
+		console.debug("Ad should've finished. Setting top offset to 0px.");
 		closeButtonOffset = 0;
 	}
 

--- a/src/jwplayer/players/shared/CloseButton.tsx
+++ b/src/jwplayer/players/shared/CloseButton.tsx
@@ -5,7 +5,7 @@ import IconCrossTiny from '@fandom-frontend/react-common/dist/icons/IconCrossTin
 import { PlayerContext } from 'jwplayer/players/shared/PlayerContext';
 import { jwPlayerPlaybackTracker } from 'jwplayer/utils/videoTracking';
 
-const CloseWrapper = styled.div`
+const CloseWrapper = styled.div<{ topOffset?: number }>`
 	cursor: pointer;
 	pointer-events: initial;
 	height: 36px;
@@ -16,7 +16,7 @@ const CloseWrapper = styled.div`
 	opacity: 0.98;
 	position: absolute;
 	right: 0;
-	top: 0;
+	top: ${(props) => (props.topOffset ? `${props.topOffset}px` : 0)};
 	z-index: ${Number(WDSVariables.z7) + 1};
 `;
 
@@ -26,9 +26,10 @@ const CrossIcon = styled(IconCrossTiny)`
 
 interface CloseButtonProps {
 	dismiss: () => void;
+	topOffset?: number;
 }
 
-const CloseButton: React.FC<CloseButtonProps> = ({ dismiss }) => {
+const CloseButton: React.FC<CloseButtonProps> = ({ dismiss, topOffset }) => {
 	const { player } = useContext(PlayerContext);
 	const onClickClose = () => {
 		jwPlayerPlaybackTracker({ event_name: 'video_player_close' });
@@ -37,7 +38,7 @@ const CloseButton: React.FC<CloseButtonProps> = ({ dismiss }) => {
 	};
 
 	return (
-		<CloseWrapper onClick={onClickClose}>
+		<CloseWrapper topOffset={topOffset} onClick={onClickClose}>
 			<CrossIcon />
 		</CloseWrapper>
 	);

--- a/src/jwplayer/players/shared/JWEvents.ts
+++ b/src/jwplayer/players/shared/JWEvents.ts
@@ -23,6 +23,8 @@ const JWEvents = {
 	AD_STARTED: 'adStarted',
 	AD_FINISHED: 'adComplete',
 	AD_TIME: 'adTime',
+	AD_BREAK_START: 'adBreakStart',
+	AD_BREAK_END: 'adBreakEnd',
 
 	// Playlist
 	PLAYLIST_LOADED: 'playlist',

--- a/src/utils/useAdBreak.ts
+++ b/src/utils/useAdBreak.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect, useContext } from 'react';
+import { PlayerContext } from 'jwplayer/players/shared/PlayerContext';
+import JWEvents from 'jwplayer/players/shared/JWEvents';
+
+export default function useAdBreak(): boolean {
+	const [adBreak, setAdBreak] = useState(false);
+	const { player } = useContext(PlayerContext);
+
+	useEffect(() => {
+		player?.on(JWEvents.AD_BREAK_START, () => {
+			console.log('AD_BREAK_START');
+			setAdBreak(true);
+		});
+		player?.on(JWEvents.AD_STARTED, () => {
+			console.log('AD_STARTED');
+			setAdBreak(true);
+		});
+		player?.on(JWEvents.AD_LOADED, () => {
+			console.log('AD_LOADED');
+			setAdBreak(true);
+		});
+		player?.on(JWEvents.AD_PLAY, () => {
+			console.log('AD_PLAY');
+			setAdBreak(true);
+		});
+
+		player?.on(JWEvents.AD_BREAK_END, () => {
+			console.log('AD_BREAK_END');
+			setAdBreak(false);
+		});
+		player?.on(JWEvents.AD_FINISHED, () => {
+			console.log('AD_FINISHED');
+			setAdBreak(false);
+		});
+	}, [player]);
+
+	return adBreak;
+}

--- a/src/utils/useAdBreak.ts
+++ b/src/utils/useAdBreak.ts
@@ -8,28 +8,28 @@ export default function useAdBreak(): boolean {
 
 	useEffect(() => {
 		player?.on(JWEvents.AD_BREAK_START, () => {
-			console.log('AD_BREAK_START');
+			console.debug('AD_BREAK_START');
 			setAdBreak(true);
 		});
 		player?.on(JWEvents.AD_STARTED, () => {
-			console.log('AD_STARTED');
+			console.debug('AD_STARTED');
 			setAdBreak(true);
 		});
 		player?.on(JWEvents.AD_LOADED, () => {
-			console.log('AD_LOADED');
+			console.debug('AD_LOADED');
 			setAdBreak(true);
 		});
 		player?.on(JWEvents.AD_PLAY, () => {
-			console.log('AD_PLAY');
+			console.debug('AD_PLAY');
 			setAdBreak(true);
 		});
 
 		player?.on(JWEvents.AD_BREAK_END, () => {
-			console.log('AD_BREAK_END');
+			console.debug('AD_BREAK_END');
 			setAdBreak(false);
 		});
 		player?.on(JWEvents.AD_FINISHED, () => {
-			console.log('AD_FINISHED');
+			console.debug('AD_FINISHED');
 			setAdBreak(false);
 		});
 	}, [player]);

--- a/test-jw/src/App.js
+++ b/test-jw/src/App.js
@@ -1,10 +1,13 @@
 import CanonicalVideoLoader from '@fandom/jwplayer-fandom/CanonicalVideoLoader'
+import MobileArticleVideoLoader from '@fandom/jwplayer-fandom/MobileArticleVideoLoader'
 import { WIREWAX_VIDEO, CANONICAL_VIDEO, ARTICLE_VIDEO_DETAILS } from './videoConfigs';
+import './app.css';
 
 function App() {
   return (
     <div className="App">
-		  <CanonicalVideoLoader currentVideo={CANONICAL_VIDEO} />
+		  {/*<CanonicalVideoLoader currentVideo={CANONICAL_VIDEO} />*/}
+      <MobileArticleVideoLoader videoDetails={ARTICLE_VIDEO_DETAILS} />
     </div>
   );
 }

--- a/test-jw/src/app.css
+++ b/test-jw/src/app.css
@@ -1,0 +1,10 @@
+.App {
+    margin-bottom: 18px;
+    max-width: 858px;
+    /*padding-top: 56.25%;*/
+    position: relative;
+}
+
+body {
+    height: 200vh;
+}


### PR DESCRIPTION
* The close button needs to be moved down, below the Learn More overlay, whenever an ad plays
* Added in a react hook to check whether the player is in an ad or not
* The close button is moved down by a static amount of 40px. Grabbing the Learn More button element is slightly difficult, given that the element exists inside of an iFrame that's sourced from a different domain