### PR TITLE
DPAD | Add video metrics

### DIFF
--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -3,7 +3,7 @@ import { JWPlayerApi, PlaylistItem, OnPlaylistItemEventData } from 'jwplayer/typ
 import FandomWirewaxPlugin from 'jwplayer/plugins/fandom-wirewax.plugin';
 import { PlayerContext } from 'jwplayer/players/shared/PlayerContext';
 import { JwPlayerWrapperProps } from 'jwplayer/types';
-import { jwPlayerPlaybackTracker } from 'jwplayer/utils/videoTracking';
+import { jwPlayerPlaybackTracker, triggerVideoMetric } from 'jwplayer/utils/videoTracking';
 import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import JWEvents from 'jwplayer/players/shared/JWEvents';
 import addBaseTrackingEvents from 'jwplayer/players/shared/addBaseTrackingEvents';
@@ -41,6 +41,7 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({ config, playerUrl, on
 		const onload = () => {
 			jwPlayerPlaybackTracker({ event_name: 'video_player_load' });
 			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY);
+			triggerVideoMetric('loaded');
 			const registerPlugin = window.jwplayer().registerPlugin;
 			registerPlugin('wirewax', '8.0', FandomWirewaxPlugin);
 
@@ -53,6 +54,7 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({ config, playerUrl, on
 
 			playerInstance.on(JWEvents.READY, (event) => {
 				recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_READY);
+				triggerVideoMetric('ready');
 				// only add the events after the player is ready
 				jwPlayerPlaybackTracker({ event_name: 'video_player_ready' });
 				addBaseTrackingEvents(playerInstance);

--- a/src/jwplayer/players/shared/addBaseTrackingEvents.ts
+++ b/src/jwplayer/players/shared/addBaseTrackingEvents.ts
@@ -18,6 +18,7 @@ import {
 	jwPlayerAdTracker,
 	jwPlayerContentTracker,
 	singleTrack,
+	triggerVideoMetric,
 } from 'jwplayer/utils/videoTracking';
 import { getVideoStartupTime, recordVideoEvent, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import { getAssetId } from 'jwplayer/utils/globalJWInterface';
@@ -72,18 +73,21 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				jwPlayerContentTracker({
 					event_name: 'video_content_quartile_25',
 				});
+				triggerVideoMetric('25-percent');
 			}
 
 			if (event.position >= event.duration * 0.5 && singleTrack('jw-player-video-50' + mediaId)) {
 				jwPlayerContentTracker({
 					event_name: 'video_content_quartile_50',
 				});
+				triggerVideoMetric('50-percent');
 			}
 
 			if (event.position >= event.duration * 0.75 && singleTrack('jw-player-video-75' + mediaId)) {
 				jwPlayerContentTracker({
 					event_name: 'video_content_quartile_75',
 				});
+				triggerVideoMetric('75-percent');
 			}
 
 			// 10s interval events firing
@@ -113,6 +117,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 			jwPlayerContentTracker({
 				event_name: 'video_content_completed',
 			});
+			triggerVideoMetric('100-percent');
 		})
 		// Controls
 		.on(JWEvents.PAUSE, (event: PausePlayerEventData) => {
@@ -120,6 +125,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				jwPlayerPlaybackTracker({
 					event_name: 'video_pause',
 				});
+				triggerVideoMetric('paused');
 			}
 		})
 		.on(JWEvents.MUTE, (event: MutePlayerEventData) => {
@@ -186,6 +192,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 		// Errors
 		.on(JWEvents.ERROR, (event: OnErrorEventData) => {
 			console.warn(event);
+			triggerVideoMetric('error', event.code.toString());
 
 			jwPlayerPlaybackTracker({
 				event_name: 'video_player_error',
@@ -211,6 +218,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				event_name: 'video_ad_started',
 				...getAdPropsFromAdEvent(event),
 			});
+			triggerVideoMetric('adstarted');
 		})
 		.on(JWEvents.AD_FINISHED, (event: AdEvents) => {
 			console.log('ad_finished', event);
@@ -218,6 +226,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				event_name: 'video_ad_completed',
 				...getAdPropsFromAdEvent(event),
 			});
+			triggerVideoMetric('adfinished');
 		})
 		.on(JWEvents.AD_TIME, (event: OnAdTimeEventData) => {
 			const mediaId = getAssetId();

--- a/src/jwplayer/players/shared/addBaseTrackingEvents.ts
+++ b/src/jwplayer/players/shared/addBaseTrackingEvents.ts
@@ -65,6 +65,7 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 					video_time_to_first_frame: timeToFirstFrame,
 					video_startup_time: getVideoStartupTime(),
 				});
+				triggerVideoMetric('started');
 			}
 		})
 		.on(JWEvents.TIME, (event: OnVideoTimeEventData) => {

--- a/src/jwplayer/utils/videoTracking.ts
+++ b/src/jwplayer/utils/videoTracking.ts
@@ -133,8 +133,6 @@ export const jwPlayerAdTracker = trackerWithNewCategory(EVENT_CATEGORIES.AD);
 export const jwPlayerContentTracker = trackerWithNewCategory(EVENT_CATEGORIES.CONTENT);
 export const jwPlayerWirewaxTracker = trackerWithNewCategory(EVENT_CATEGORIES.WIREWAX);
 
-console.log(jwPlayerContentTracker);
-
 const mappings = new Set<string>();
 export function singleTrack(eventName: string) {
 	if (mappings.has(eventName)) {

--- a/src/jwplayer/utils/videoTracking.ts
+++ b/src/jwplayer/utils/videoTracking.ts
@@ -20,7 +20,7 @@ import {
 } from 'jwplayer/utils/globalJWInterface';
 import addGlobalProps from 'jwplayer/utils/videoTrackingGlobalProps';
 import getVideoPlayerVersion from 'jwplayer/utils/getVideoPlayerVersion';
-import triggerMetric from "@fandom/tracking-metrics/metrics/metric";
+import triggerMetric from '@fandom/tracking-metrics/metrics/metric';
 
 // https://docs.google.com/spreadsheets/d/1jEn61uIP8dYE8KQP3nrMG3nePFArgxrs3Q4lxTcArZQ/edit#gid=1564524057
 export const PROPERTY_NAMES = {

--- a/src/jwplayer/utils/videoTracking.ts
+++ b/src/jwplayer/utils/videoTracking.ts
@@ -20,6 +20,7 @@ import {
 } from 'jwplayer/utils/globalJWInterface';
 import addGlobalProps from 'jwplayer/utils/videoTrackingGlobalProps';
 import getVideoPlayerVersion from 'jwplayer/utils/getVideoPlayerVersion';
+import triggerMetric from "@fandom/tracking-metrics/metrics/metric";
 
 // https://docs.google.com/spreadsheets/d/1jEn61uIP8dYE8KQP3nrMG3nePFArgxrs3Q4lxTcArZQ/edit#gid=1564524057
 export const PROPERTY_NAMES = {
@@ -142,4 +143,16 @@ export function singleTrack(eventName: string) {
 
 	mappings.add(eventName);
 	return true;
+}
+
+/**
+ * Additional DW event recording with sampling for engineering usage. This will allow us to make charts and graphs
+ * to monitor releases via the realtime and historical tables
+ */
+export function triggerVideoMetric(metric: string, label?: string, value = 1, sample = 0.2) {
+	try {
+		triggerMetric(`video-player:${metric}`, value, sample, label ?? metric);
+	} catch (e) {
+		console.warn('VideoMetric Warning for ' + metric);
+	}
 }


### PR DESCRIPTION
In order to enable the engineering team to view real-time and historical metrics for some of the key stats, let's use our metric library, which sends our video events to the DW special tracking table in a sampled fashion (20% of events). Even though this does increase the number of events were are sending (although a much smaller subset) our queries should be much less expensive. 

Events:
* Player loaded
* Player ready
* Paused
* Played
* Ad started
* Ad completed 