### PR TITLE
Publish non beta version of the new video player

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-beta-30",
+	"version": "2.0.0",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",


### PR DESCRIPTION
Ditch the beta postfix for the package version; Start fresh with a fresh 2.0.0, since the new player has been released to 100% of wikis now