### PR TITLE
DPAD-1175: Fix desktop mini-player viewability 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0",
+	"version": "2.0.0-safari-scroll-bug-10",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-safari-scroll-bug-10",
+	"version": "2.0.0-safari-scroll-bug-11",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.0-safari-scroll-bug-11",
+	"version": "2.0.4",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -52,6 +52,7 @@ const DesktopArticleVideoWrapper = styled.div<DesktopArticleVideoWrapperProps>`
 					z-index: ${Number(WDSVariables.z2) + 2};
 					position: fixed;
 					animation: ${moveDownAnimation(props.right, props.width)} 0.4s normal forwards;
+					-webkit-transform: translate3d(0, 0, 0);
 			  `
 			: css`
 					position: absolute;

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import WDSVariables from '@fandom-frontend/design-system/dist/variables.json';
-import styled, { css, keyframes } from 'styled-components';
+import styled, { css } from 'styled-components';
 import UnmuteButton from 'jwplayer/players/DesktopArticleVideoPlayer/UnmuteButton';
 import JwPlayerWrapper from 'jwplayer/players/shared/JwPlayerWrapper';
 import VideoDetails from 'jwplayer/players/DesktopArticleVideoPlayer/VideoDetails';
@@ -14,6 +14,7 @@ import { getArticleVideoConfig } from 'jwplayer/utils/articleVideo/articleVideoC
 import articlePlayerOnReady from 'jwplayer/utils/articleVideo/articlePlayerOnReady';
 
 const DesktopArticleVideoTopPlaceholder = styled.div`
+	z-index: ${Number(WDSVariables.z2) + 2};
 	position: absolute;
 	width: 100%;
 	padding-top: 56.25%;
@@ -22,20 +23,6 @@ const DesktopArticleVideoTopPlaceholder = styled.div`
 	bottom: 0;
 	right: 0;
 	z-index: 2;
-`;
-
-const moveDownAnimation = (right: number, width: number) => keyframes`
-	from {
-		right: ${right}px;
-		bottom: 100%;
-		width: ${width}px;
-	}
-
-	to {
-		right: 18px;
-		bottom: 45px;
-		width: 300px;  
-	}
 `;
 
 interface DesktopArticleVideoWrapperProps {
@@ -49,10 +36,10 @@ const DesktopArticleVideoWrapper = styled.div<DesktopArticleVideoWrapperProps>`
 	${(props) =>
 		props.isScrollPlayer
 			? css`
-					z-index: ${Number(WDSVariables.z2) + 2};
 					position: fixed;
-					animation: ${moveDownAnimation(props.right, props.width)} 0.4s normal forwards;
-					-webkit-transform: translate3d(0, 0, 0);
+					right: 18px;
+					bottom: 45px;
+					width: 300px;
 			  `
 			: css`
 					position: absolute;
@@ -60,8 +47,6 @@ const DesktopArticleVideoWrapper = styled.div<DesktopArticleVideoWrapperProps>`
 					right: 0;
 					top: 0;
 					left: 0;
-					transform: translateZ(0);
-					-webkit-transform: translateZ(0);
 			  `}
 `;
 

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -58,7 +58,7 @@ const TopBar = styled.div`
 const DesktopArticleVideoPlayer: React.FC<DesktopArticleVideoPlayerProps> = ({ videoDetails }) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
 	const adComplete = useAdComplete();
-	const onScreen = useOnScreen(placeholderRef, '0px', 0.1);
+	const onScreen = useOnScreen(placeholderRef, '0px', 0.5);
 	const [dismissed, setDismissed] = useState(false);
 	const isScrollPlayer = !(dismissed || onScreen);
 	const boundingClientRect = placeholderRef.current?.getBoundingClientRect();


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/DPAD-1175

## Acceptance Criteria
- [ ] Desktop scroll player should be visible on safari.
- [ ] Scroll animation for player removed
- [ ] Scroll player now activates at 50% visibility
