### PR TITLE
DPAD-1213 :: Stop auto-advancement if the player is not viewable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.5",
+	"version": "2.0.5-stop-autoadvancement-10",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.5-stop-autoadvancement-11",
+	"version": "2.0.7",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.5-stop-autoadvancement-10",
+	"version": "2.0.5-stop-autoadvancement-11",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -98,7 +98,7 @@ const DesktopArticleVideoPlayer: React.FC<DesktopArticleVideoPlayerProps> = ({ v
 						<JwPlayerWrapper
 							config={getArticleVideoConfig(videoDetails)}
 							onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
-							pauseOnExitViewport={true}
+							stopAutoAdvanceOnExitViewport={true}
 						/>
 						{isScrollPlayer && <VideoDetails />}
 					</DesktopArticleVideoWrapper>

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -98,6 +98,7 @@ const DesktopArticleVideoPlayer: React.FC<DesktopArticleVideoPlayerProps> = ({ v
 						<JwPlayerWrapper
 							config={getArticleVideoConfig(videoDetails)}
 							onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
+							pauseOnExitViewport={true}
 						/>
 						{isScrollPlayer && <VideoDetails />}
 					</DesktopArticleVideoWrapper>

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -100,7 +100,7 @@ const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
 						<JwPlayerWrapper
 							config={getArticleVideoConfig(videoDetails)}
 							onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
-							pauseOnExitViewport={true}
+							stopAutoAdvanceOnExitViewport={true}
 						/>
 						<OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />
 					</MobileArticleVideoWrapper>

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -100,6 +100,7 @@ const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
 						<JwPlayerWrapper
 							config={getArticleVideoConfig(videoDetails)}
 							onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
+							pauseOnExitViewport={true}
 						/>
 						<OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />
 					</MobileArticleVideoWrapper>

--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -25,7 +25,13 @@ const getDefaultPlayerUrl = () => {
 		: 'https://content.jwplatform.com/libraries/VXc5h4Tf.js';
 };
 
-const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({ config, playerUrl, onReady, onComplete }) => {
+const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
+	config,
+	playerUrl,
+	onReady,
+	onComplete,
+	pauseOnExitViewport,
+}) => {
 	const { setPlayer, setConfig } = useContext(PlayerContext);
 	const videoIndexRef = React.useRef(0);
 	const defaultConfig = {
@@ -94,7 +100,12 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({ config, playerUrl, on
 			});
 
 			playerInstance.on(JWEvents.PLAYLIST_ITEM, () => {
-				// if the video is on its 2nd play, pause the video if its not on screen
+				// if pauseOnExitViewport is set to false we want the normal behavior for the player
+				if (!pauseOnExitViewport) {
+					return;
+				}
+
+				// if the video is on its 2nd+ play, pause the video if its not on the viewport
 				if (videoIndexRef.current >= 1 && playerInstance.getViewable() === 0) {
 					// send tracking event
 					jwPlayerPlaybackTracker({ event_name: 'video_player_pause_not_viewable' });

--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -27,6 +27,7 @@ const getDefaultPlayerUrl = () => {
 
 const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({ config, playerUrl, onReady, onComplete }) => {
 	const { setPlayer, setConfig } = useContext(PlayerContext);
+	const videoIndexRef = React.useRef(0);
 	const defaultConfig = {
 		plugins: { fandomWirewax: {} },
 	};
@@ -86,6 +87,18 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({ config, playerUrl, on
 			playerInstance.on(JWEvents.COMPLETE, () => {
 				if (typeof onComplete === 'function') {
 					onComplete();
+				}
+
+				// Incrementing videos watched count
+				videoIndexRef.current += 1;
+			});
+
+			playerInstance.on(JWEvents.PLAYLIST_ITEM, () => {
+				// if the video is on its 2nd play, pause the video if its not on screen
+				if (videoIndexRef.current >= 1 && playerInstance.getViewable() === 0) {
+					// send tracking event
+					jwPlayerPlaybackTracker({ event_name: 'video_player_pause_not_viewable' });
+					playerInstance.stop();
 				}
 			});
 

--- a/src/jwplayer/players/shared/LoadableVideoPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/LoadableVideoPlayerWrapper.tsx
@@ -19,6 +19,7 @@ const LoadableVideoPlayerWrapper: React.FC<LoadableVideoPlayerWrapperProps> = ({
 			config={playerConfig}
 			playerUrl={'https://content.jwplatform.com/libraries/tcoydixg.js'}
 			onComplete={onComplete}
+			pauseOnExitViewport={false}
 		/>
 	);
 };

--- a/src/jwplayer/players/shared/LoadableVideoPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/LoadableVideoPlayerWrapper.tsx
@@ -19,7 +19,7 @@ const LoadableVideoPlayerWrapper: React.FC<LoadableVideoPlayerWrapperProps> = ({
 			config={playerConfig}
 			playerUrl={'https://content.jwplatform.com/libraries/tcoydixg.js'}
 			onComplete={onComplete}
-			pauseOnExitViewport={false}
+			stopAutoAdvanceOnExitViewport={false}
 		/>
 	);
 };

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -287,7 +287,7 @@ export interface JwPlayerWrapperProps {
 	playerUrl?: string;
 	onReady?: (playerInstance: Player) => void;
 	onComplete?: () => void;
-	pauseOnExitViewport?: boolean;
+	stopAutoAdvanceOnExitViewport?: boolean;
 }
 
 export interface LoadableVideoPlayerWrapperProps {

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -287,6 +287,7 @@ export interface JwPlayerWrapperProps {
 	playerUrl?: string;
 	onReady?: (playerInstance: Player) => void;
 	onComplete?: () => void;
+	pauseOnExitViewport?: boolean;
 }
 
 export interface LoadableVideoPlayerWrapperProps {

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -164,6 +164,7 @@ interface PlaylistItemCallbackData {
 
 export type Player = {
 	playToggle: () => null;
+	stop: () => null;
 	pause: () => null;
 	play: () => null;
 	setMute: (mute: boolean | null) => null;

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -144,6 +144,8 @@ type JwEventHandler = (event?: JwEventData) => void;
 
 interface BasePluginInterface {
 	on: (name: string, handler: (method: JwEventData) => void) => Player;
+	close?: () => void;
+	open?: () => void;
 }
 
 interface Plugins {
@@ -189,6 +191,7 @@ export type Player = {
 	getFullscreen: () => boolean;
 	getFloating: () => boolean;
 	plugins: Plugins;
+	getPlugin: (name: string) => BasePluginInterface;
 	getQualityLevels: () => QualityObject[];
 	load: (playlist: string | Playlist) => null;
 	setPlaylistItemCallback: (PlaylistItemCallbackData) => void;

--- a/test-jw/src/App.js
+++ b/test-jw/src/App.js
@@ -1,5 +1,7 @@
 import CanonicalVideoLoader from '@fandom/jwplayer-fandom/CanonicalVideoLoader'
 import MobileArticleVideoLoader from '@fandom/jwplayer-fandom/MobileArticleVideoLoader'
+import DesktopArticleVideoLoader from '@fandom/jwplayer-fandom/DesktopArticleVideoLoader'
+
 import { WIREWAX_VIDEO, CANONICAL_VIDEO, ARTICLE_VIDEO_DETAILS } from './videoConfigs';
 import './app.css';
 
@@ -7,7 +9,7 @@ function App() {
   return (
     <div className="App">
 		  {/*<CanonicalVideoLoader currentVideo={CANONICAL_VIDEO} />*/}
-      <MobileArticleVideoLoader videoDetails={ARTICLE_VIDEO_DETAILS} />
+      <DesktopArticleVideoLoader videoDetails={ARTICLE_VIDEO_DETAILS} />
     </div>
   );
 }


### PR DESCRIPTION
### Issue

[DPAD-1213](https://fandom.atlassian.net/browse/DPAD-1213)

### Description

JW has a built-in option to prevent auto-starting until the player is in “view” (“viewable” from an advertiser perspective, >50% of pixels). However, this setting only affects the initial play. If “related” plays continue afterward, they will start regardless of the player’s visibility.

This PR addresses this issue by counting the number of videos that has been watched and then stopping the player if its not on screen (at least 50% on the screen according to JW).


#### Why an external index instead of JW's `index` on `playlistItem` callback ?

Simply because that index changes when another playlist is selected (be it manually or automatically), so its not reliable enough to be used to count watched videos.

### Links

[sandbox-s7](https://paweltest2.sandbox-s7.fandom.com/wiki/Test-video)