### PR TITLE
Dpad-995 :: experiment logic test for Desktop Article Video Loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"@babel/preset-env": "^7.16.5",
 		"@babel/preset-react": "^7.16.5",
 		"@babel/preset-typescript": "^7.16.5",
-		"@fandom/pathfinder-lite": "1.0.0",
+		"@fandom/pathfinder-lite": "1.0.2",
 		"@fandom-frontend/eslint-config": "^3.0.0",
 		"@fandom-frontend/prettier-config": "^2.1.0",
 		"@rollup/plugin-babel": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",
-		"./DesktopArticleVideoLoader" : "./DesktopArticleVideoLoader.js", 
-		"./MobileArticleVideoLoader" : "./MobileArticleVideoLoader.js", 
-		"./CanonicalVideoLoader" : "./CanonicalVideoLoader.js"
+		"./DesktopArticleVideoLoader": "./DesktopArticleVideoLoader.js",
+		"./MobileArticleVideoLoader": "./MobileArticleVideoLoader.js",
+		"./CanonicalVideoLoader": "./CanonicalVideoLoader.js"
 	},
 	"types": "main.d.ts",
 	"install-peers": "install-peers",
@@ -78,7 +78,7 @@
 		"@babel/preset-env": "^7.16.5",
 		"@babel/preset-react": "^7.16.5",
 		"@babel/preset-typescript": "^7.16.5",
-		"@fandom/pathfinder-bucketing": "0.0.1",
+		"@fandom/pathfinder-lite": "1.0.0",
 		"@fandom-frontend/eslint-config": "^3.0.0",
 		"@fandom-frontend/prettier-config": "^2.1.0",
 		"@rollup/plugin-babel": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"@babel/preset-env": "^7.16.5",
 		"@babel/preset-react": "^7.16.5",
 		"@babel/preset-typescript": "^7.16.5",
+		"@fandom/pathfinder-bucketing": "0.0.1",
 		"@fandom-frontend/eslint-config": "^3.0.0",
 		"@fandom-frontend/prettier-config": "^2.1.0",
 		"@rollup/plugin-babel": "5.3.0",

--- a/src/loaders/DesktopArticleVideoLoader.tsx
+++ b/src/loaders/DesktopArticleVideoLoader.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { DesktopArticleVideoLoaderProps } from 'loaders/types';
 import { setVersionWindowVar } from 'loaders/utils/GetVersion';
-import defineExperiment from '@fandom/pathfinder-bucketing/experiments/defineExperiment';
-import getExperiment from '@fandom/pathfinder-bucketing/experiments/getExperiment';
-import { Experiment } from '@fandom/pathfinder-bucketing/types';
+import defineExperiment from '@fandom/pathfinder-lite/experiments/defineExperiment';
+import getExperiment from '@fandom/pathfinder-lite/experiments/getExperiment';
+import { Experiment } from '@fandom/pathfinder-lite/types';
 
 export { getVideoPlayerVersion } from 'loaders/utils/GetVersion';
 
@@ -26,9 +26,8 @@ export const DesktopArticleVideoLoader: React.FC<DesktopArticleVideoLoaderProps>
 	const getPlayer = async () => {
 		const currentExperiment: Experiment = getExperiment([desktopReskinnedExperiment]);
 
-		// By default just set the base player
+		// By default if there is no experiment just set the base player
 		if (!currentExperiment) {
-			console.log('Loading plain Desktop Article Video Player');
 			import('jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer').then(
 				({ default: JWDesktopArticleVideoPlayer }) =>
 					setPlayer(<JWDesktopArticleVideoPlayer videoDetails={videoDetails} />),
@@ -38,7 +37,7 @@ export const DesktopArticleVideoLoader: React.FC<DesktopArticleVideoLoaderProps>
 		}
 
 		if (currentExperiment?.name === desktopReskinnedExperiment?.name) {
-			console.log('Loading re-skinned Desktop Article Video Player');
+			currentExperiment.log.info('Loading re-skinned Desktop Article Video Player');
 			import('experimental/players/DesktopReskinnedArticleVideoPlayer/DesktopReskinnedArticleVideoPlayer').then(
 				({ default: JWDesktopReskinnedArticleVideoPlayer }) =>
 					setPlayer(<JWDesktopReskinnedArticleVideoPlayer videoDetails={videoDetails} />),
@@ -46,7 +45,6 @@ export const DesktopArticleVideoLoader: React.FC<DesktopArticleVideoLoaderProps>
 		}
 	};
 
-	console.log('Returning player: ', player);
 	return player;
 };
 

--- a/src/loaders/DesktopArticleVideoLoader.tsx
+++ b/src/loaders/DesktopArticleVideoLoader.tsx
@@ -1,8 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { DesktopArticleVideoLoaderProps } from 'loaders/types';
 import { setVersionWindowVar } from 'loaders/utils/GetVersion';
+import defineExperiment from '@fandom/pathfinder-bucketing/experiments/defineExperiment';
+import getExperiment from '@fandom/pathfinder-bucketing/experiments/getExperiment';
+import { Experiment } from '@fandom/pathfinder-bucketing/types';
 
 export { getVideoPlayerVersion } from 'loaders/utils/GetVersion';
+
+const desktopReskinnedExperiment = defineExperiment({
+	name: 'desktop-reskinned-player',
+	buckets: ['z', 'a'],
+});
+
+const currentExperimentBeforeLoad: Experiment = getExperiment([desktopReskinnedExperiment]);
 
 export const DesktopArticleVideoLoader: React.FC<DesktopArticleVideoLoaderProps> = ({ videoDetails }) => {
 	const [player, setPlayer] = useState(undefined);
@@ -17,6 +27,15 @@ export const DesktopArticleVideoLoader: React.FC<DesktopArticleVideoLoaderProps>
 
 	const getPlayer = async () => {
 		const isReskinned = true; // TODO: add logic for experiment check
+		const currentExperiment: Experiment = getExperiment([desktopReskinnedExperiment]);
+		console.log('defined experiment: ', desktopReskinnedExperiment);
+		console.log(`experiment: ${currentExperiment}`);
+		console.log(`experiment before load value: ${currentExperimentBeforeLoad}`);
+		if (currentExperiment?.name === desktopReskinnedExperiment?.name) {
+			console.log('Should be inside experiment.');
+		} else {
+			console.log('Not inside experiment');
+		}
 
 		if (isReskinned) {
 			console.log('Loading re-skinned Desktop Article Video Player');

--- a/src/loaders/DesktopArticleVideoLoader.tsx
+++ b/src/loaders/DesktopArticleVideoLoader.tsx
@@ -24,45 +24,26 @@ export const DesktopArticleVideoLoader: React.FC<DesktopArticleVideoLoaderProps>
 	}, []);
 
 	const getPlayer = async () => {
-		const experimentPromise = new Promise((resolve) => {
-			console.log('Should be inside promise.');
-			let isReskinned = false;
-			const currentExperiment: Experiment = getExperiment([desktopReskinnedExperiment]);
-			console.log('defined experiment: ', desktopReskinnedExperiment);
-			console.log(`experiment: ${currentExperiment}`);
-			if (currentExperiment && currentExperiment?.name === desktopReskinnedExperiment?.name) {
-				console.log('Should be inside experiment.');
-				isReskinned = true;
-			} else {
-				console.log('Not inside experiment');
-			}
-			resolve(isReskinned);
-		})
-			.then((isReskinned: boolean) => {
-				console.log('Inside promise then statement with passed down isReskinned value');
-				console.log('Is reskinned is: ', isReskinned);
-				if (isReskinned) {
-					console.log('Loading re-skinned Desktop Article Video Player');
-					import('experimental/players/DesktopReskinnedArticleVideoPlayer/DesktopReskinnedArticleVideoPlayer').then(
-						({ default: JWDesktopReskinnedArticleVideoPlayer }) =>
-							setPlayer(<JWDesktopReskinnedArticleVideoPlayer videoDetails={videoDetails} />),
-					);
-				} else {
-					console.log('Loading plain Desktop Article Video Player');
-					// By default just set the base player
-					import('jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer').then(
-						({ default: JWDesktopArticleVideoPlayer }) =>
-							setPlayer(<JWDesktopArticleVideoPlayer videoDetails={videoDetails} />),
-					);
-				}
-			})
-			.then(() => {
-				console.log('Should return player from Promise: ', player);
-				return player;
-			});
+		const currentExperiment: Experiment = getExperiment([desktopReskinnedExperiment]);
 
-		return await experimentPromise;
-		// TODO: add logic for experiment check
+		// By default just set the base player
+		if (!currentExperiment) {
+			console.log('Loading plain Desktop Article Video Player');
+			import('jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer').then(
+				({ default: JWDesktopArticleVideoPlayer }) =>
+					setPlayer(<JWDesktopArticleVideoPlayer videoDetails={videoDetails} />),
+			);
+
+			return;
+		}
+
+		if (currentExperiment?.name === desktopReskinnedExperiment?.name) {
+			console.log('Loading re-skinned Desktop Article Video Player');
+			import('experimental/players/DesktopReskinnedArticleVideoPlayer/DesktopReskinnedArticleVideoPlayer').then(
+				({ default: JWDesktopReskinnedArticleVideoPlayer }) =>
+					setPlayer(<JWDesktopReskinnedArticleVideoPlayer videoDetails={videoDetails} />),
+			);
+		}
 	};
 
 	console.log('Returning player: ', player);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,6 +1172,14 @@
     react-select "^5.2.1"
     styled-components "^5.0.1"
 
+"@fandom/context@^0.4.1":
+  version "0.4.1"
+  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/context/-/@fandom/context-0.4.1.tgz#08bf918e4e713b80146b146bd8b6190716181826"
+  integrity sha512-ni7fn1/SMRYwBfT1kaV3yT3MdGKGcAzh9nKtLkMOXN0a1IPsLWknx5WbSiaiYTGULIL6WhznPlO4ERvyxHGx7A==
+  dependencies:
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+
 "@fandom/context@^0.6.1":
   version "0.6.2"
   resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/context/-/@fandom/context-0.6.2.tgz#54037825118c1c4a32a0ddfdb7da0340c455a892"
@@ -1179,6 +1187,13 @@
   dependencies:
     lodash "^4.17.21"
     lodash-es "^4.17.21"
+
+"@fandom/pathfinder-bucketing@0.0.1":
+  version "0.0.1"
+  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/pathfinder-bucketing/-/@fandom/pathfinder-bucketing-0.0.1.tgz#dfe229f9fb6fecaeff3a16a5a45d4d1dcbda9926"
+  integrity sha512-vQBR87KzTg6XxSBXY+C49a2l+ckJ6AhacgVe6yoWPTDEG7LjWKamJ8fvO9QMQzf8I+Gc6XI4wRyOylnyCKFZXg==
+  dependencies:
+    "@fandom/context" "^0.4.1"
 
 "@fandom/tracking-metrics@0.0.18-alpha-2":
   version "0.0.18-alpha-2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,10 +1188,10 @@
     lodash "^4.17.21"
     lodash-es "^4.17.21"
 
-"@fandom/pathfinder-lite@1.0.0":
-  version "1.0.0"
-  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/pathfinder-lite/-/@fandom/pathfinder-lite-1.0.0.tgz#b39528b7694c4ef2cddd9eba70315a4477eb5b56"
-  integrity sha512-LFM61ZnOSHbM9IXRYrxZgoFB0B2iFsanumnMmnXLSi0qkzWlZUjPTfH18ZRi/TmDLk8HiC46BRlD01a4LYkN5A==
+"@fandom/pathfinder-lite@1.0.2":
+  version "1.0.2"
+  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/pathfinder-lite/-/@fandom/pathfinder-lite-1.0.2.tgz#ad107ad05fa8abeb7f4f0630a7c481a5e3d68674"
+  integrity sha512-W6cnUlMz9m6RQQOj05U747DTPSZQitK22KVMq59hKctNbUh37MPSFPkThFyXEoMkdPSVq9k/ZV7RqQuIlRpdbg==
   dependencies:
     "@fandom/context" "^0.6.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,14 +1172,6 @@
     react-select "^5.2.1"
     styled-components "^5.0.1"
 
-"@fandom/context@^0.4.1":
-  version "0.4.1"
-  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/context/-/@fandom/context-0.4.1.tgz#08bf918e4e713b80146b146bd8b6190716181826"
-  integrity sha512-ni7fn1/SMRYwBfT1kaV3yT3MdGKGcAzh9nKtLkMOXN0a1IPsLWknx5WbSiaiYTGULIL6WhznPlO4ERvyxHGx7A==
-  dependencies:
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-
 "@fandom/context@^0.6.1":
   version "0.6.2"
   resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/context/-/@fandom/context-0.6.2.tgz#54037825118c1c4a32a0ddfdb7da0340c455a892"
@@ -1188,12 +1180,20 @@
     lodash "^4.17.21"
     lodash-es "^4.17.21"
 
-"@fandom/pathfinder-bucketing@0.0.1":
-  version "0.0.1"
-  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/pathfinder-bucketing/-/@fandom/pathfinder-bucketing-0.0.1.tgz#dfe229f9fb6fecaeff3a16a5a45d4d1dcbda9926"
-  integrity sha512-vQBR87KzTg6XxSBXY+C49a2l+ckJ6AhacgVe6yoWPTDEG7LjWKamJ8fvO9QMQzf8I+Gc6XI4wRyOylnyCKFZXg==
+"@fandom/context@^0.6.2":
+  version "0.6.3"
+  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/context/-/@fandom/context-0.6.3.tgz#810a4993cd6e64f5eff9eb71d9723242d20e0219"
+  integrity sha512-6THxJdnEuaqS9q813d+HMEnl55FOlOcIhVW1JL2Wu3OtT47LJBjiJLwCkrtKy1vAYnpnsmvfrm1Cw1ztoSBAwg==
   dependencies:
-    "@fandom/context" "^0.4.1"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+
+"@fandom/pathfinder-lite@1.0.0":
+  version "1.0.0"
+  resolved "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/pathfinder-lite/-/@fandom/pathfinder-lite-1.0.0.tgz#b39528b7694c4ef2cddd9eba70315a4477eb5b56"
+  integrity sha512-LFM61ZnOSHbM9IXRYrxZgoFB0B2iFsanumnMmnXLSi0qkzWlZUjPTfH18ZRi/TmDLk8HiC46BRlD01a4LYkN5A==
+  dependencies:
+    "@fandom/context" "^0.6.2"
 
 "@fandom/tracking-metrics@0.0.18-alpha-2":
   version "0.0.18-alpha-2"


### PR DESCRIPTION
* Added in the pathfinder-lite library to take advantage of the bucketing logic
* Added in buckets p and q as test buckets (subject to change)
* Added in pathfinder-lite bucketing logic to ensure that the reskinned player will load

Notes:
The query string `pf_pathfinder_force_bucket=p` or `pf_pathfinder_force_bucket=q` can be used to force the experiment, by providing this query param on the browser.  P and Q buckets can be replaced with any other buckets, as long as they're reflected in the defineExperiment function.