### PR TITLE
DPAD-1337 :: Fix Canonical Video Player AdEng configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/src/jwplayer/players/CanonicalVideoPlayer/CanonicalVideoPlayer.tsx
+++ b/src/jwplayer/players/CanonicalVideoPlayer/CanonicalVideoPlayer.tsx
@@ -48,7 +48,7 @@ const CanonicalVideoPlayer: React.FC<CanonicalVideoPlayerProps> = ({ currentVide
 		};
 
 		// if the player's mounted communicate that the video platform is ready
-		communicationService.dispatch({ type: '[F2] Configured', payload });
+		communicationService.dispatch({ type: '[F2] Configured', ...payload });
 	}, []);
 
 	return (


### PR DESCRIPTION
Use the spread operator on the AdEng config payload object instead of passing in the whole object - it should be passed in as { ...payload } not { payload }