### PR TITLE
DPAD-1410 :: Added in an optional prop to the JwPlayerWrapper called …

### DIFF
--- a/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
+++ b/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
@@ -54,7 +54,11 @@ const TopBar = styled.div`
 	position: relative;
 `;
 
-const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({ videoDetails, showScrollPlayer }) => {
+const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
+	videoDetails,
+	showScrollPlayer,
+	jwPlayerContainerEmbedId,
+}) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
 	console.debug('RedVentureVideoPlayer: ad complete always true');
 	// const adComplete = useAdComplete();
@@ -96,6 +100,7 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({ videoDeta
 							onReady={(playerInstance) => redVenturePlayerOnReady(videoDetails, playerInstance)}
 							stopAutoAdvanceOnExitViewport={false}
 							shouldLoadSponsoredContentList={false}
+							jwPlayerContainerEmbedId={jwPlayerContainerEmbedId}
 						/>
 						{isScrollPlayer && <VideoDetails />}
 					</RedVentureVideoWrapper>

--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -33,6 +33,7 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 	className,
 	stopAutoAdvanceOnExitViewport,
 	shouldLoadSponsoredContentList = true,
+	jwPlayerContainerEmbedId = 'featured-video__player',
 }) => {
 	const { setPlayer, setConfig } = useContext(PlayerContext);
 	const videoIndexRef = React.useRef(0);
@@ -59,7 +60,7 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 			console.debug('Loading of Sponsored Content Video List was disabled.');
 		}
 		recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_INIT_RENDER);
-		initPlayer('featured-video__player', playerUrl);
+		initPlayer(jwPlayerContainerEmbedId, playerUrl);
 	}, []);
 
 	const initPlayer = (elementId: string, playerUrl?: string) => {
@@ -145,7 +146,7 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 
 	return (
 		<div className={className}>
-			<div id="featured-video__player" />
+			<div id={jwPlayerContainerEmbedId} />
 		</div>
 	);
 };

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -378,7 +378,7 @@ export interface CanonicalVideoPlayerProps {
 	onComplete: () => void;
 }
 
-export interface JwPlayerWrapperProps {
+export interface JwPlayerWrapperProps extends JwPlayerContainerId {
 	config?: PlayerConfig;
 	playerUrl?: string;
 	onReady?: (playerInstance: Player) => void;
@@ -386,6 +386,18 @@ export interface JwPlayerWrapperProps {
 	className?: string;
 	stopAutoAdvanceOnExitViewport?: boolean;
 	shouldLoadSponsoredContentList?: boolean;
+}
+
+export interface JwPlayerContainerId {
+	/**
+	 * @description An optional parameter that sets the id of the div element on which the JW Player embeds itself on.
+	 * @default featured-video__player
+	 * @example
+	 * {
+	 *   embedElementId: 'featured-video__player1'
+	 * }
+	 * */
+	jwPlayerContainerEmbedId?: string;
 }
 
 export interface LoadableVideoPlayerWrapperProps {
@@ -401,7 +413,7 @@ export interface DesktopArticleVideoPlayerProps {
 	videoDetails: ArticleVideoDetails;
 }
 
-export interface RedVentureVideoPlayerProps {
+export interface RedVentureVideoPlayerProps extends JwPlayerContainerId {
 	videoDetails: ArticleVideoDetails;
 	showScrollPlayer: boolean;
 }

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -394,7 +394,7 @@ export interface JwPlayerContainerId {
 	 * @default featured-video__player
 	 * @example
 	 * {
-	 *   embedElementId: 'featured-video__player1'
+	 *   jwPlayerContainerEmbedId: 'featured-video__player1'
 	 * }
 	 * */
 	jwPlayerContainerEmbedId?: string;

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -394,7 +394,7 @@ export interface JwPlayerContainerId {
 	 * @default featured-video__player
 	 * @example
 	 * {
-	 *   jwPlayerContainerEmbedId: 'featured-video__player1'
+	 *   jwPlayerContainerEmbedId: 'customContainerId'
 	 * }
 	 * */
 	jwPlayerContainerEmbedId?: string;

--- a/src/stand-alone/loaderHelper.ts
+++ b/src/stand-alone/loaderHelper.ts
@@ -1,6 +1,6 @@
-import { RedVentureVideoDetails, RequireOnlyOne } from 'jwplayer/types';
+import { JwPlayerContainerId, RedVentureVideoDetails, RequireOnlyOne } from 'jwplayer/types';
 
-export interface RedVenturePlayerContext {
+export interface RedVenturePlayerContext extends JwPlayerContainerId {
 	/**
 	 * @description Describes the location where the video player is being embedded. Useful for adding context to video tracking events
 	 */
@@ -40,6 +40,17 @@ export interface RedVenturePlayerContext {
 	 * }
 	 * */
 	showScrollPlayer?: boolean;
+	/**
+	 * @description An option that allows the JwPlayer Container Id to be auto incremented, by keeping track of how many times the window.loadPlayer function has been called.
+	 * When this option is enabled, it'll ignore the jwPlayerContainerEmbedId option, and use the default value of 'featured-video__player'. When the first player is instantiated,
+	 * the JWPlayer Container Id will be set to 'featured-video__player_1', to prevent clashes with the default id of 'featured-video__player'. If at any point, a player gets instantiated
+	 * on the same page with this option turned off, the player id number counter will not be incremented.
+	 * @example
+	 * {
+	 *   autoIncrementJwPlayerContainerId: true
+	 * }
+	 * */
+	autoIncrementJwPlayerContainerId?: boolean;
 }
 
 export type RedVenturePlayerContextProps = RequireOnlyOne<

--- a/src/stand-alone/standalone-loader.tsx
+++ b/src/stand-alone/standalone-loader.tsx
@@ -33,6 +33,27 @@ declare let window: WindowWithRedVentureJWPlayer;
  *
  * */
 
+let jwPlayerContainerIdIncrementCounter = 0;
+
+const getJwPlayerContainerEmbedId = (context: RedVenturePlayerContextProps): string => {
+	if (context?.autoIncrementJwPlayerContainerId) {
+		jwPlayerContainerIdIncrementCounter += 1;
+		console.debug(
+			`Auto increment option for the JWPlayer Container Id has been enabled. The next increment value is ${jwPlayerContainerIdIncrementCounter}.`,
+		);
+		return `featured-video__player_${jwPlayerContainerIdIncrementCounter}`;
+	}
+
+	if (context?.jwPlayerContainerEmbedId) {
+		console.debug(
+			`A jwPlayerContainerEmbedId value has been found. The JW Player container's id will be ${context?.jwPlayerContainerEmbedId}`,
+		);
+		return context?.jwPlayerContainerEmbedId;
+	}
+
+	return null;
+};
+
 window.loadPlayer = async (context: RedVenturePlayerContextProps) => {
 	const canProceed = canPlayerRender(context);
 
@@ -47,11 +68,11 @@ window.loadPlayer = async (context: RedVenturePlayerContextProps) => {
 	const videoWrapperElement = getVideoWrapperElement(context);
 	videoWrapperElement.innerHTML = '';
 
-	console.debug('Loading in the RedVentureVideoPlayer in the standalone-loader');
 	ReactDOM.render(
 		React.createElement(RedVentureVideoPlayer, {
 			videoDetails: redVentureVideoDetails,
 			showScrollPlayer: context?.showScrollPlayer ?? false,
+			jwPlayerContainerEmbedId: getJwPlayerContainerEmbedId(context),
 		} as RedVentureVideoPlayerProps),
 		reactRoot,
 	);


### PR DESCRIPTION
…jwPlayerContainerEmbedId, which has a default value of 'featured-video__player' - this allows the jw container id value to be set dynamically, fixing issues with multiple players embeds on the same page | Added in an autoIncrementJwPlayerContainerId to the RedVenture video player, to allow the jw container id to be auto-incremented by values of 1 - an example of a 2nd video's jw player container id that's embedded on a page would be featured-video__player_2; this property takes precedence over the jwPlayerContainerEmbedId property