### PR TITLE
DPAD-1371 :: Add in AdEng support to the RedVenture (PlayerOne) Video Players

### DIFF
--- a/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
+++ b/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
@@ -5,7 +5,7 @@ import UnmuteButton from 'jwplayer/players/DesktopArticleVideoPlayer/UnmuteButto
 import JwPlayerWrapper from 'jwplayer/players/shared/JwPlayerWrapper';
 import VideoDetails from 'jwplayer/players/DesktopArticleVideoPlayer/VideoDetails';
 import useOnScreen from 'utils/useOnScreen';
-/* import useAdComplete from 'jwplayer/utils/useAdComplete'; */
+import useAdComplete from 'jwplayer/utils/useAdComplete';
 import PlayerWrapper from 'jwplayer/players/shared/PlayerWrapper';
 import { RedVentureVideoPlayerProps } from 'jwplayer/types';
 import CloseButton from 'jwplayer/players/shared/CloseButton';
@@ -60,8 +60,9 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
 	jwPlayerContainerEmbedId,
 }) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
-	// const adComplete = useAdComplete();
-	const adComplete = true;
+	const adComplete = useAdComplete();
+	console.debug('adComplete state: ', adComplete);
+	// const adComplete = true;
 	const onScreen = useOnScreen(placeholderRef, '0px', 0.5);
 	const [dismissed, setDismissed] = useState(false);
 	const isScrollPlayer = showScrollPlayer ? !(dismissed || onScreen) : false;

--- a/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
+++ b/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
@@ -61,8 +61,8 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
 }) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
 	const adComplete = useAdComplete();
+	// TODO: Remove before deploying final version. Keep during dev cycle.
 	console.debug('adComplete state: ', adComplete);
-	// const adComplete = true;
 	const onScreen = useOnScreen(placeholderRef, '0px', 0.5);
 	const [dismissed, setDismissed] = useState(false);
 	const isScrollPlayer = showScrollPlayer ? !(dismissed || onScreen) : false;

--- a/src/jwplayer/players/RedVentureVideoPlayer/redVenturePlayerOnReady.ts
+++ b/src/jwplayer/players/RedVentureVideoPlayer/redVenturePlayerOnReady.ts
@@ -2,8 +2,10 @@ import { communicationService } from 'jwplayer/utils/communication';
 import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import { RedVentureVideoDetails } from 'jwplayer/types';
 
+const jwPlayerKeyCounter = 0;
+
 export default function useOnRedVenturePlayerReady(videoDetails: RedVentureVideoDetails, playerInstance): void {
-	const playerKey = 'aeJWPlayerKey';
+	const playerKey = 'aeJWPlayerKey' + (jwPlayerKeyCounter === 0 ? '' : jwPlayerKeyCounter);
 
 	window.dispatchEvent(new CustomEvent('wikia.jwplayer.instanceReady', { detail: playerInstance }));
 	window[playerKey] = playerInstance;

--- a/src/jwplayer/players/RedVentureVideoPlayer/redVenturePlayerOnReady.ts
+++ b/src/jwplayer/players/RedVentureVideoPlayer/redVenturePlayerOnReady.ts
@@ -2,10 +2,11 @@ import { communicationService } from 'jwplayer/utils/communication';
 import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import { RedVentureVideoDetails } from 'jwplayer/types';
 
-const jwPlayerKeyCounter = 0;
+let jwPlayerKeyCounter = 0;
 
 export default function useOnRedVenturePlayerReady(videoDetails: RedVentureVideoDetails, playerInstance): void {
 	const playerKey = 'aeJWPlayerKey' + (jwPlayerKeyCounter === 0 ? '' : jwPlayerKeyCounter);
+	jwPlayerKeyCounter++;
 
 	window.dispatchEvent(new CustomEvent('wikia.jwplayer.instanceReady', { detail: playerInstance }));
 	window[playerKey] = playerInstance;

--- a/src/jwplayer/players/RedVentureVideoPlayer/redVenturePlayerOnReady.ts
+++ b/src/jwplayer/players/RedVentureVideoPlayer/redVenturePlayerOnReady.ts
@@ -5,6 +5,8 @@ import { RedVentureVideoDetails } from 'jwplayer/types';
 let jwPlayerKeyCounter = 0;
 
 export default function useOnRedVenturePlayerReady(videoDetails: RedVentureVideoDetails, playerInstance): void {
+	// Increment the jwPlayerKeyCounter in cases where multiple video players have to be embedded.
+	// A unique playerKey will allow control of each unique JW Player that's embedded on the page, through the JW Player API.
 	const playerKey = 'aeJWPlayerKey' + (jwPlayerKeyCounter === 0 ? '' : jwPlayerKeyCounter);
 	jwPlayerKeyCounter++;
 

--- a/src/jwplayer/utils/useAdComplete.ts
+++ b/src/jwplayer/utils/useAdComplete.ts
@@ -9,6 +9,7 @@ export default function useAdComplete(): boolean {
 	const [adComplete, setAdComplete] = useState(false);
 
 	useEffect(() => {
+		// TODO: Remove before deploying final version. Keep during dev cycle.
 		if (window.location.search.includes('skip_ad_complete')) {
 			console.debug("JW Player skip_ad_complete was found. setAdComplete will resolve to 'true'.");
 			setAdComplete(true);

--- a/src/jwplayer/utils/useAdComplete.ts
+++ b/src/jwplayer/utils/useAdComplete.ts
@@ -9,14 +9,34 @@ export default function useAdComplete(): boolean {
 	const [adComplete, setAdComplete] = useState(false);
 
 	useEffect(() => {
+		if (window.location.search.includes('skip_ad_complete')) {
+			console.debug("JW Player skip_ad_complete was found. setAdComplete will resolve to 'true'.");
+			setAdComplete(true);
+			return;
+		}
+
+		console.debug(
+			'AdEngine Steps: \n ' +
+				'All AdEng Setup Steps in JW Player: \n\n' +
+				'useAdComplete step 1: ${VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START} \n' +
+				"useAdComplete step 2: '[AdEngine OptIn] set opt in' \n" +
+				"useAdComplete step 3: 'Wait for AdEngine' \n" +
+				"useAdComplete step 4: 'listenSetupJWPlayer' \n" +
+				'End All AdEng Setup Steps in JW Player \n\n',
+		);
+
 		recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START);
+		console.debug(`useAdComplete step 1: ${VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_OPT_IN_LISTEN_START}`);
 		communicationService.action$.pipe(ofType('[AdEngine OptIn] set opt in'), first()).subscribe(() => {
+			console.debug(`useAdComplete step 2: '[AdEngine OptIn] set opt in'`);
 			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_OPT_IN_MESSAGE_RECIEVED);
 			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_CONFIG_LISTEN_START);
 			waitForAdEngine().then(() => {
+				console.debug(`useAdComplete step 3: 'Wait for AdEngine'`);
 				recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_CONFIG_MESSAGE_RECIEVED);
 				recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_SETUP_JW_LISTEN_START);
 				listenSetupJWPlayer(function () {
+					console.debug(`useAdComplete step 4: 'listenSetupJWPlayer'`);
 					recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_AD_ENG_SETUP_JW_MESSAGE_RECIEVED);
 					setAdComplete(true);
 				});


### PR DESCRIPTION
- Added in a jwPlayerKey incrementor, for cases where there are multiple RedVenture video players on sites such as gamespot's seemless article pages
- Added in multiple debug log statements around AdEng calls for easier debugging during the dev cycle; comments/TODOs have been added to remove those before deploying to Prod, if necessary.