### PR TITLE
DPAD-1440 :: Allow Signed Content to work with the RedVenture video player

### DIFF
--- a/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
+++ b/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
@@ -58,6 +58,7 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
 	videoDetails,
 	showScrollPlayer,
 	jwPlayerContainerEmbedId,
+	playerUrl,
 }) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
 	const adComplete = useAdComplete();
@@ -101,6 +102,7 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
 							stopAutoAdvanceOnExitViewport={false}
 							shouldLoadSponsoredContentList={false}
 							jwPlayerContainerEmbedId={jwPlayerContainerEmbedId}
+							playerUrl={playerUrl}
 						/>
 						{isScrollPlayer && <VideoDetails />}
 					</RedVentureVideoWrapper>

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -416,6 +416,7 @@ export interface DesktopArticleVideoPlayerProps {
 export interface RedVentureVideoPlayerProps extends JwPlayerContainerId {
 	videoDetails: ArticleVideoDetails;
 	showScrollPlayer: boolean;
+	playerUrl?: string;
 }
 
 export interface MobileArticleVideoPlayerProps {

--- a/src/stand-alone/loaderHelper.ts
+++ b/src/stand-alone/loaderHelper.ts
@@ -51,6 +51,31 @@ export interface RedVenturePlayerContext extends JwPlayerContainerId {
 	 * }
 	 * */
 	autoIncrementJwPlayerContainerId?: boolean;
+	/**
+	 * @description An optional parameter that allows the JW Player URL to be passed in, and used by the JW Player library. The player URL will decide which player should be loaded.
+	 * The JW Players have different properties, and could be spread across different workspaces. The playerUrl can also take in a signed url, for workspaces
+	 * where the player is protected by signed urls. The signed player urls are non-jwt signed urls.
+	 * More information on this can be found at - https://docs.jwplayer.com/platform/reference/protect-your-content-with-signed-urls#types-of-signed-urls
+	 * @example - unsigned URL example
+	 * {
+	 *   playerUrl: 'https://cdn.jwplayer.com/libraries/VXc5h4Tf.js'
+	 * },
+	 * @example - signed URL example
+	 * {
+	 *   playerUrl: 'https://cdn.jwplayer.com/libraries/5cvxbGL3.js?sig=abc123zzzaaa&exp=1674168554'
+	 * }
+	 * */
+	playerUrl?: string;
+	/**
+	 * @description A JSON Web Token (JWT) for use with JW Player media ids that are Externally Hosted.
+	 * This token must be passed in whenever the JW Workspace that the mediaId is associated with is protected.
+	 * You can find out more details about content protection with signed urls by following this link - https://docs.jwplayer.com/platform/reference/protect-your-content-with-signed-urls
+	 * @example
+	 * {
+	 *   jwtSignedContentAuth: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2NzQyNjIzODA2MDAsInJlc291cmNlIjoiL3YyL21lZGlhL2dic25YOW9KIiwiaWF0IjoxNjc0MjYyMzc2fQ.uZs5BYQe-_4IrDeMJCeEMcLF41RmpgrVyzt6PEKi1_I'
+	 * }
+	 * */
+	jwtSignedContentAuth?: string;
 }
 
 export type RedVenturePlayerContextProps = RequireOnlyOne<
@@ -58,9 +83,22 @@ export type RedVenturePlayerContextProps = RequireOnlyOne<
 	'embedSelector' | 'embedHtmlElement'
 >;
 
-export async function getVideoDetails(mediaId: string) {
+/*
+ * If a JW Auth Token is passed in, then generate the correct query String.
+ * If nothing is passed in, then just return a blank string.
+ * */
+const getJWMediaAuthToken = (context: RedVenturePlayerContextProps) => {
+	if (context?.jwtSignedContentAuth) {
+		return `?token=${context.jwtSignedContentAuth}`;
+	}
+	return '';
+};
+
+export async function getVideoDetails(context: RedVenturePlayerContextProps) {
+	const mediaId = context?.mediaId;
+	const mediaUrl = `https://cdn.jwplayer.com/v2/media/${mediaId}${getJWMediaAuthToken(context)}`;
 	try {
-		const response = await fetch('https://cdn.jwplayer.com/v2/media' + '/' + mediaId, {
+		const response = await fetch(mediaUrl, {
 			method: 'get',
 		});
 

--- a/src/stand-alone/standalone-loader.tsx
+++ b/src/stand-alone/standalone-loader.tsx
@@ -61,7 +61,7 @@ window.loadPlayer = async (context: RedVenturePlayerContextProps) => {
 		throw new Error('Could not render the video player. The requirements for initialization were not met.');
 	}
 
-	const jwMediaDetails = await getVideoDetails(context.mediaId);
+	const jwMediaDetails = await getVideoDetails(context);
 	const redVentureVideoDetails: RedVentureVideoDetails = buildRedVentureVideoDetails(jwMediaDetails);
 
 	const reactRoot = document.createElement('div');
@@ -73,6 +73,7 @@ window.loadPlayer = async (context: RedVenturePlayerContextProps) => {
 			videoDetails: redVentureVideoDetails,
 			showScrollPlayer: context?.showScrollPlayer ?? false,
 			jwPlayerContainerEmbedId: getJwPlayerContainerEmbedId(context),
+			playerUrl: context?.playerUrl,
 		} as RedVentureVideoPlayerProps),
 		reactRoot,
 	);


### PR DESCRIPTION
- Added in support for Signed urls for the JW Player
- Added in the jwtSignedContentAuth param to the standalone-loader.tsx, which is appended to the /v2/media API call. This is only useful if the workspace in which the mediaId (or/and the player as depending on content protection setup in the JW Dashboard) is located in, is protected by Signed Urls
- Added in a playerUrl param to the standalone-loader.tsx, which passes down the playerUrl to the RedVentureVideoPlayer.tsx, and eventually passes in the playerUrl to the already JwPlayerWrapper component (which has already existed). This param was added in to allow the application that instantiates this player to decide what player should be used, and can only be used to add in a Signed Url for the player (as per the JW Dashboard setup of the workspace that the player is located in)