### PR TITLE
DPAD-1490 :: Check if window.Phoenix.hasAds is an actual function

### DIFF
--- a/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
+++ b/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
@@ -72,7 +72,9 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
 	playerUrl,
 }) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
-	const hasAds = window?.Phoenix?.hasAds() ?? true;
+	// Check if Ads are disabled on any of the N&R Games sites. If the resolving function is not present, then always resolve to connecting with AdEng.
+	const hasAds =
+		window?.Phoenix?.hasAds && typeof window?.Phoenix?.hasAds === 'function' ? window.Phoenix.hasAds() : true;
 	const adComplete = useRvAdComplete(hasAds);
 	const onScreen = useOnScreen(placeholderRef, '0px', 0.5);
 	const [dismissed, setDismissed] = useState(false);


### PR DESCRIPTION
Check if window.Phoenix.hasAds is an actual function and if it can be called; on GameFAQs the key of hasAds is defined on the window.Phoenix object but is actually undefined for some reason, this should not prevent the player from instantiating on the page and crashing