### PR TITLE
DPAD-1494 :: Switch out the hasAds functionality 

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"pub:minor": "npm version minor && rm -rf dist && yarn pub",
 		"pub:major": "npm version major && rm -rf dist && yarn pub",
 		"pub": "yarn install && yarn build && cd dist && npm publish --tag beta",
-		"purgeSingleFile": "ts-node --project stand-alone/tsconfig-stand-alone.json stand-alone/deploy/purge/purgeSingleFile.ts"
+		"purgeSingleFile": "ts-node --project stand-alone/tsconfig-stand-alone.json stand-alone/deploy/purge/purgeSingleFile.ts",
+		"serveFilesOnBrowser": "npx browser-sync start --server --files \"**/.js\""
 	},
 	"lint-staged": {
 		"src/**/*.(ts|tsx|js)": [

--- a/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
+++ b/src/jwplayer/players/RedVentureVideoPlayer/RedVentureVideoPlayer.tsx
@@ -13,8 +13,12 @@ import redVenturePlayerOnReady from 'jwplayer/players/RedVentureVideoPlayer/redV
 import { getRedVentureVideoConfig } from 'jwplayer/players/RedVentureVideoPlayer/getRedVentureVideoConfig';
 import { disableTimingEventsSamplingRate } from 'jwplayer/utils/videoTimingEvents';
 
+interface PhoenixUser {
+	isPremium?: () => boolean;
+}
+
 interface Phoenix {
-	hasAds?: () => boolean;
+	User?: PhoenixUser;
 }
 
 interface WindowWithPhoenix extends Window {
@@ -74,8 +78,12 @@ const RedVentureVideoPlayer: React.FC<RedVentureVideoPlayerProps> = ({
 }) => {
 	const placeholderRef = useRef<HTMLDivElement>(null);
 	// Check if Ads are disabled on any of the N&R Games sites. If the resolving function is not present, then always resolve to connecting with AdEng.
+	// This check should only apply to the GiantBomb N&R site. Safeguards are added in for other sites, where this function may not be defined.
+	// If the user is a GiantBomb premium user, then let's flag the video player as not having ads. Premium users should not see video ads.
 	const hasAds =
-		window?.Phoenix?.hasAds && typeof window?.Phoenix?.hasAds === 'function' ? window.Phoenix.hasAds() : true;
+		window?.Phoenix?.User?.isPremium && typeof window?.Phoenix?.User?.isPremium === 'function'
+			? !window.Phoenix.User.isPremium()
+			: true;
 	const adComplete = useRvAdComplete(hasAds);
 	const onScreen = useOnScreen(placeholderRef, '0px', 0.5);
 	const [dismissed, setDismissed] = useState(false);

--- a/stand-alone/package.json
+++ b/stand-alone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/rv-jwplayer",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "JWPlayer for News and Rating sites (previously RedVenture) e.g. GameSpot, GameFAQs, GiantBomb, ComicVine, TVGuide and Metacritic",
 	"types": "types.d.ts",
 	"install-peers": "install-peers",


### PR DESCRIPTION
Switch out the hasAds functionality with the !window.Phoenix.User.isPremium() check, so that this check is more specific to GiantBomb (GB)