### PR TITLE
COTECH-683 (fix): handle missing duration property

### DIFF
--- a/src/jwplayer/utils/formatTime.ts
+++ b/src/jwplayer/utils/formatTime.ts
@@ -1,15 +1,19 @@
+function isNumber(value: unknown): boolean {
+	return typeof value === 'number' && !isNaN(value);
+}
+
 export function formatTime(duration: number): string {
+	// If duration is below 0 seconds or is not a number it means corrupted data, we don't want to display it
+	// Also return early for 0 seconds
+	if (duration <= 0 || !isNumber(duration)) {
+		return '00:00';
+	}
+
 	const hours = Math.floor(duration / 3600);
 	const minutes = Math.floor((duration - hours * 3600) / 60);
 	const seconds = Math.floor(duration - hours * 3600 - minutes * 60);
 
 	let durationStr = '';
-
-	// If duration is below 0 seconds it means corrupted data, we don't want to display it
-	// Also return early for 0 seconds
-	if (duration <= 0) {
-		return '00:00';
-	}
 
 	if (hours > 0) {
 		durationStr += `${hours < 10 ? '0' : ''}${hours}:`;


### PR DESCRIPTION
[Ticket](https://fandom.atlassian.net/browse/COTECH-683)

I noticed that for some videos (for example first video on the Yoda page) instead of the video duration there is `NaN:NaN` displayed. Currently, there is an if statement that checks if property `duration` is less or equal to zero but it doesn't take into account situations when duration is missing (it's the case for Yoda's video).

Also, it's better to move this statement as a first instruction in the function - we don't want to compute anything if the duration is not a number.

cc @Wikia/site-experience @Wikia/cotech 