### PR TITLE
FCPPT-103: Fix jwplayer placeholder issues

### DIFF
--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -51,7 +51,7 @@ export const DesktopArticleVideoPlayerContent: React.FC<DesktopArticleVideoPlaye
 							isScrollPlayer ? styles.desktopArticleVideoWrapperScrollPlayer : styles.desktopArticleVideoWrapper
 						}
 					>
-						{isPlayerReady ? (
+						{adComplete && (
 							<div>
 								<div className={styles.topBar}>
 									{!isScrollPlayer && <UnmuteButton />}
@@ -68,12 +68,11 @@ export const DesktopArticleVideoPlayerContent: React.FC<DesktopArticleVideoPlaye
 									}}
 									stopAutoAdvanceOnExitViewport={false}
 								/>
-								{isScrollPlayer && <VideoDetails />}
+								{isScrollPlayer && isPlayerReady && <VideoDetails />}
 								<input type="hidden" value={String(dismissed)} name={inputName} />
 							</div>
-						) : (
-							<VideoPlaceholder isScrollPlayer={isScrollPlayer} />
 						)}
+						{!isPlayerReady && <VideoPlaceholder isScrollPlayer={isScrollPlayer} />}
 					</div>
 				}
 			</div>

--- a/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/DesktopArticleVideoPlayer/DesktopArticleVideoPlayer.tsx
@@ -26,6 +26,7 @@ export const DesktopArticleVideoPlayerContent: React.FC<DesktopArticleVideoPlaye
 	const moreVideosIcon = document.querySelector<HTMLElement>('.jw-controlbar .jw-button-container .jw-related-btn');
 	const pipIcon = document.querySelector<HTMLElement>('.jw-controlbar .jw-button-container .jw-icon-pip');
 	const inputName = 'isDismissed';
+	const [isPlayerReady, setIsPlayerReady] = useState(false);
 
 	const getDismissed = getDismissedFn(inputName);
 
@@ -50,7 +51,7 @@ export const DesktopArticleVideoPlayerContent: React.FC<DesktopArticleVideoPlaye
 							isScrollPlayer ? styles.desktopArticleVideoWrapperScrollPlayer : styles.desktopArticleVideoWrapper
 						}
 					>
-						{adComplete ? (
+						{isPlayerReady ? (
 							<div>
 								<div className={styles.topBar}>
 									{!isScrollPlayer && <UnmuteButton />}
@@ -61,7 +62,10 @@ export const DesktopArticleVideoPlayerContent: React.FC<DesktopArticleVideoPlaye
 								<JwPlayerWrapper
 									getDismissed={getDismissed}
 									config={getArticleVideoConfig(videoDetails)}
-									onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
+									onReady={(playerInstance) => {
+										articlePlayerOnReady(videoDetails, playerInstance);
+										setIsPlayerReady(true);
+									}}
 									stopAutoAdvanceOnExitViewport={false}
 								/>
 								{isScrollPlayer && <VideoDetails />}

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -102,7 +102,7 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 		<>
 			<div ref={ref} className={clsx(styles.mobileArticleVideoTopPlaceholder, isScrollPlayer && `is-on-scroll-active`)}>
 				<MobileArticleVideoWrapper isScrollPlayer={isScrollPlayer} topPosition={getTopPosition()}>
-					{adComplete ? (
+					{isPlayerReady ? (
 						<>
 							<JwPlayerWrapper
 								getDismissed={getDismissed}
@@ -115,7 +115,7 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 							/>
 							<input type="hidden" value={String(dismissed)} name={inputName} />
 
-							{isPlayerReady && <OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />}
+							<OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />
 						</>
 					) : (
 						<VideoPlaceholder isScrollPlayer={isScrollPlayer} />

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -102,7 +102,7 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 		<>
 			<div ref={ref} className={clsx(styles.mobileArticleVideoTopPlaceholder, isScrollPlayer && `is-on-scroll-active`)}>
 				<MobileArticleVideoWrapper isScrollPlayer={isScrollPlayer} topPosition={getTopPosition()}>
-					{isPlayerReady ? (
+					{adComplete && (
 						<>
 							<JwPlayerWrapper
 								getDismissed={getDismissed}
@@ -115,11 +115,10 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 							/>
 							<input type="hidden" value={String(dismissed)} name={inputName} />
 
-							<OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />
+							{isPlayerReady && <OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />}
 						</>
-					) : (
-						<VideoPlaceholder isScrollPlayer={isScrollPlayer} />
 					)}
+					{!isPlayerReady && <VideoPlaceholder isScrollPlayer={isScrollPlayer} />}
 				</MobileArticleVideoWrapper>
 			</div>
 			<Attribution />

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -53,6 +53,7 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 	const isScrollPlayer = !(dismissed || onScreen);
 	const inputName = 'isDismissed';
 	const relatedContainer = document.getElementById('featured-video__player_related') as HTMLDivElement | null;
+	const [isPlayerReady, setIsPlayerReady] = useState(false);
 
 	const getDismissed = getDismissedFn(inputName);
 
@@ -106,12 +107,15 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 							<JwPlayerWrapper
 								getDismissed={getDismissed}
 								config={getArticleVideoConfig(videoDetails)}
-								onReady={(playerInstance) => articlePlayerOnReady(videoDetails, playerInstance)}
+								onReady={(playerInstance) => {
+									articlePlayerOnReady(videoDetails, playerInstance);
+									setIsPlayerReady(true);
+								}}
 								stopAutoAdvanceOnExitViewport={false}
 							/>
 							<input type="hidden" value={String(dismissed)} name={inputName} />
 
-							<OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />
+							{isPlayerReady && <OffScreenOverlay isScrollPlayer={isScrollPlayer} dismiss={() => setDismissed(true)} />}
 						</>
 					) : (
 						<VideoPlaceholder isScrollPlayer={isScrollPlayer} />

--- a/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/videoDetails.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/videoDetails.module.scss
@@ -15,7 +15,7 @@
 .videoDetailsWrapperCollapsed {
 	background-color: token(wdsColorWhite);
 	transform: translate(0, 100%);
-	box-shadow: 0 2px 4px -2px rgba(0,0,0,.2);
+	box-shadow: 0 2px 4px -2px rgba(0, 0, 0, 0.2);
 }
 
 .videoTitle {

--- a/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/videoDetails.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/videoDetails.module.scss
@@ -15,7 +15,7 @@
 .videoDetailsWrapperCollapsed {
 	background-color: token(wdsColorWhite);
 	transform: translate(0, 100%);
-	box-shadow: 0 2px 4px 0 rgba(0,0,0,.2);
+	box-shadow: 0 2px 4px -2px rgba(0,0,0,.2);
 }
 
 .videoTitle {

--- a/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/videoDetails.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/OffScreenOverlay/videoDetails.module.scss
@@ -15,6 +15,7 @@
 .videoDetailsWrapperCollapsed {
 	background-color: token(wdsColorWhite);
 	transform: translate(0, 100%);
+	box-shadow: 0 2px 4px 0 rgba(0,0,0,.2);
 }
 
 .videoTitle {

--- a/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
@@ -1,9 +1,10 @@
 .mobileArticleVideoTopPlaceholder {
+	--z1: token(z1);
 	width: 100%;
 	height: 56.25vw;
 	position: relative;
-	// must be bigger than infobox button
-	z-index: 101;
+	// z-index must be bigger than infobox button
+	z-index: calc(var(--z1 + 1);
 }
 
 .mobileArticleVideoWrapperIsScrollPlayer {

--- a/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
@@ -8,7 +8,6 @@
 
 .mobileArticleVideoWrapperIsScrollPlayer {
 	--z2: token(z2);
-	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
 	position: fixed;
 	width: 100%;
 	height: 56.25vw;

--- a/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
@@ -4,7 +4,7 @@
 	height: 56.25vw;
 	position: relative;
 	// z-index must be bigger than infobox button
-	z-index: calc(var(--z1 + 1);
+	z-index: calc(var(--z1 + 1));
 }
 
 .mobileArticleVideoWrapperIsScrollPlayer {

--- a/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/mobileArticleVideoPlayer.module.scss
@@ -2,7 +2,8 @@
 	width: 100%;
 	height: 56.25vw;
 	position: relative;
-	z-index: 100;
+	// must be bigger than infobox button
+	z-index: 101;
 }
 
 .mobileArticleVideoWrapperIsScrollPlayer {


### PR DESCRIPTION
https://fandom.atlassian.net/browse/FCPPT-103

Deployed: https://starwars.sandbox-xw1.fandom.com/wiki/Yoda

Description (extended from ticket description):
- The timing for showing placeholder was changes, we look now for readiness of player not `adComplete` particularly because this variable name is misleading - it triggers right after receiving jwplayer setup but jwplayer is still not rendered so placeholder should be still there in this case.
- Video details were shown before even loading video player which is why it also should wait for video player.
- Shadow was moved to the video details to not blend with fandom page.





<details>
<summary>After (sandbox on the left) vs. before (production on the right)</summary>

https://github.com/Wikia/jwplayer-fandom/assets/25872895/f733b496-9b71-4cd8-906d-14a37e8abf6b

https://github.com/Wikia/jwplayer-fandom/assets/25872895/3bbf48ff-e6fd-4e69-982e-64b1b053cda7
</details>







