### PR TITLE
COTECH-136 (step2) | configurable mobile scroll position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fandom/jwplayer-fandom",
-	"version": "2.7.2",
+	"version": "2.7.3",
 	"description": "JWPlayer for Fandom",
 	"exports": {
 		".": "./main.js",

--- a/src/contexts/MobileArticleVideoContext.ts
+++ b/src/contexts/MobileArticleVideoContext.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+type MobileArticleVideoContextType = {
+	scrollTopPosition?: string;
+};
+
+export const MobileArticleVideoContext = createContext<MobileArticleVideoContextType>({});
+
+export const useMobileArticleVideoContext = () => {
+	return useContext(MobileArticleVideoContext);
+};

--- a/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
+++ b/src/jwplayer/players/MobileArticleVideoPlayer/MobileArticleVideoPlayer.tsx
@@ -12,6 +12,7 @@ import { recordVideoEvent, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimin
 import { getArticleVideoConfig } from 'jwplayer/utils/articleVideo/articleVideoConfig';
 import articlePlayerOnReady from 'jwplayer/utils/articleVideo/articlePlayerOnReady';
 import { getDismissedFn } from 'jwplayer/utils/utils';
+import { useMobileArticleVideoContext } from 'contexts/MobileArticleVideoContext';
 
 import clsx from 'clsx';
 
@@ -19,34 +20,29 @@ import styles from './mobileArticleVideoPlayer.module.scss';
 
 interface MobileArticleVideoWrapperProps {
 	isScrollPlayer: boolean;
-	topPosition: string;
 }
 
-const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
-	isScrollPlayer,
-	topPosition,
-	children,
-}) => (
-	<div
-		className={clsx(
-			`mobile-article-video-wrapper`,
-			isScrollPlayer
-				? styles.mobileArticleVideoWrapperIsScrollPlayer
-				: styles.mobileArticleVideoWrapperIsNotScrollPlayer,
-		)}
-		style={{
-			...(isScrollPlayer && { top: topPosition }),
-		}}
-	>
-		{children}
-	</div>
-);
+const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({ isScrollPlayer, children }) => {
+	const { scrollTopPosition } = useMobileArticleVideoContext();
 
-export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerProps> = ({
-	hasPartnerSlot,
-	isFullScreen,
-	videoDetails,
-}) => {
+	return (
+		<div
+			className={clsx(
+				`mobile-article-video-wrapper`,
+				isScrollPlayer
+					? styles.mobileArticleVideoWrapperIsScrollPlayer
+					: styles.mobileArticleVideoWrapperIsNotScrollPlayer,
+			)}
+			style={{
+				...(isScrollPlayer && { top: scrollTopPosition }),
+			}}
+		>
+			{children}
+		</div>
+	);
+};
+
+export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerProps> = ({ videoDetails }) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const adComplete = useAdComplete();
 	const onScreen = useOnScreen(ref, '0px', 1);
@@ -57,22 +53,6 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 	const [isPlayerReady, setIsPlayerReady] = useState(false);
 
 	const getDismissed = getDismissedFn(inputName);
-
-	const getTopPosition = () => {
-		if (isFullScreen) {
-			return '0px';
-		}
-
-		if (hasPartnerSlot) {
-			return '75px';
-		}
-
-		return '55px';
-	};
-
-	useEffect(() => {
-		// mobileArticleVideoPlayerTracker.loaded();
-	}, []);
 
 	useEffect(() => {
 		if (!onScreen) {
@@ -87,13 +67,11 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 		}
 
 		if (!adComplete && singleTrack('ad-mobile-video-player-impression')) {
-			// mobileArticleVideoPlayerTracker.impression({ label: 'ad' }); // todo figure out label
 			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_AD);
 			return;
 		}
 
 		if (singleTrack('mobile-video-player-impression')) {
-			// mobileArticleVideoPlayerTracker.impression({ label: 'post-ad' }); // todo figure out label
 			recordVideoEvent(VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_VIDEO);
 			return;
 		}
@@ -102,7 +80,7 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 	return (
 		<>
 			<div ref={ref} className={clsx(styles.mobileArticleVideoTopPlaceholder, isScrollPlayer && `is-on-scroll-active`)}>
-				<MobileArticleVideoWrapper isScrollPlayer={isScrollPlayer} topPosition={getTopPosition()}>
+				<MobileArticleVideoWrapper isScrollPlayer={isScrollPlayer}>
 					{adComplete && (
 						<>
 							<JwPlayerWrapper
@@ -127,17 +105,9 @@ export const MobileArticleVideoPlayerContent: React.FC<MobileArticleVideoPlayerP
 	);
 };
 
-export const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
-	hasPartnerSlot,
-	isFullScreen,
-	videoDetails,
-}) => (
+export const MobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({ videoDetails }) => (
 	<PlayerWrapper playerName="jw-mobile-article-video">
-		<MobileArticleVideoPlayerContent
-			hasPartnerSlot={hasPartnerSlot}
-			isFullScreen={isFullScreen}
-			videoDetails={videoDetails}
-		/>
+		<MobileArticleVideoPlayerContent videoDetails={videoDetails} />
 	</PlayerWrapper>
 );
 

--- a/src/jwplayer/types.d.ts
+++ b/src/jwplayer/types.d.ts
@@ -474,7 +474,5 @@ export interface RedVentureVideoPlayerProps extends JwPlayerContainerId {
 }
 
 export interface MobileArticleVideoPlayerProps {
-	hasPartnerSlot?: boolean;
-	isFullScreen?: boolean;
 	videoDetails: ArticleVideoDetails;
 }

--- a/src/loaders/MobileArticleVideoLoader.tsx
+++ b/src/loaders/MobileArticleVideoLoader.tsx
@@ -2,13 +2,17 @@ import React, { useEffect, useState } from 'react';
 import { MobileArticleVideoLoaderProps } from 'loaders/types';
 import { setVersionWindowVar } from 'loaders/utils/GetVersion';
 import { shouldLoadUcpPlayer } from 'loaders/utils/shouldLoadPlayer';
+import { MobileArticleVideoContext } from 'contexts/MobileArticleVideoContext';
 
 import { eligibleForYoutubeTakeover, getYoutubeTakeoverDetails } from './utils/GetYoutubeTakeoverDetails';
 import { eligibleForVimeoTakeover, getVimeoTakeoverDetails } from './utils/GetVimeoTakeoverDetails';
 
 export { getVideoPlayerVersion } from 'loaders/utils/GetVersion';
 
-export const MobileArticleVideoLoader: React.FC<MobileArticleVideoLoaderProps> = ({ videoDetails }) => {
+export const MobileArticleVideoLoader: React.FC<MobileArticleVideoLoaderProps> = ({
+	videoDetails,
+	scrollTopPosition = '55px',
+}) => {
 	const [player, setPlayer] = useState(undefined);
 
 	useEffect(() => {
@@ -44,7 +48,9 @@ export const MobileArticleVideoLoader: React.FC<MobileArticleVideoLoaderProps> =
 		}
 	};
 
-	return player;
+	return (
+		<MobileArticleVideoContext.Provider value={{ scrollTopPosition }}>{player}</MobileArticleVideoContext.Provider>
+	);
 };
 
 export default MobileArticleVideoLoader;

--- a/src/loaders/types.d.ts
+++ b/src/loaders/types.d.ts
@@ -5,7 +5,11 @@ import {
 } from 'jwplayer/types';
 
 export type DesktopArticleVideoLoaderProps = DesktopArticleVideoPlayerProps | undefined;
-export type MobileArticleVideoLoaderProps = MobileArticleVideoPlayerProps | undefined;
+export type MobileArticleVideoLoaderProps =
+	| (MobileArticleVideoPlayerProps & {
+			scrollTopPosition?: string;
+	  })
+	| undefined;
 export type CanonicalVideoLoaderProps = CanonicalVideoPlayerProps | undefined;
 
 interface MWConfig {

--- a/src/vimeo/players/VimeoMobileArticleVideoPlayer.tsx
+++ b/src/vimeo/players/VimeoMobileArticleVideoPlayer.tsx
@@ -3,6 +3,7 @@ import VimeoPlayerWrapper from 'vimeo/players/shared/VimeoPlayerWrapper';
 import useOnScreen from 'utils/useOnScreen';
 import PlayerWrapper from 'vimeo/players/shared/PlayerWrapper';
 import { VimeoArticleVideoPlayerProps, VimeoTakeOverDetails } from 'vimeo/types';
+import { useMobileArticleVideoContext } from 'contexts/MobileArticleVideoContext';
 
 import clsx from 'clsx';
 
@@ -10,20 +11,11 @@ import styles from './VimeoMobileArticleVideoPlayer.module.css';
 import MobileVimeoOffScreenOverlay from './overlays/MobileVimeoOffScreenOverlay';
 
 interface MobileArticleVideoWrapperProps {
-	topPosition: string;
 	vimeoDetails: VimeoTakeOverDetails;
 }
 
-interface MobileArticleVideoPlayerProps extends VimeoArticleVideoPlayerProps {
-	hasPartnerSlot?: boolean;
-	isFullScreen?: boolean;
-}
-
-const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
-	vimeoDetails,
-	topPosition,
-	children,
-}) => {
+const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({ vimeoDetails, children }) => {
+	const { scrollTopPosition } = useMobileArticleVideoContext();
 	const ref = useRef<HTMLDivElement>(null);
 	const onScreen = useOnScreen(ref, '0px', 1);
 	const [dismissed, setDismissed] = useState(false);
@@ -39,7 +31,7 @@ const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
 						: styles.mobileArticleVideoWrapperIsNotScrollPlayer,
 				)}
 				style={{
-					...(isScrollPlayer && { top: topPosition }),
+					...(isScrollPlayer && { top: scrollTopPosition }),
 				}}
 			>
 				<MobileVimeoOffScreenOverlay dismiss={() => setDismissed(true)} isScrollPlayer={isScrollPlayer} />
@@ -50,26 +42,10 @@ const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
 	);
 };
 
-const VimeoMobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
-	hasPartnerSlot,
-	isFullScreen,
-	vimeoDetails,
-}) => {
-	const getTopPosition = () => {
-		if (isFullScreen) {
-			return '0px';
-		}
-
-		if (hasPartnerSlot) {
-			return '75px';
-		}
-
-		return '55px';
-	};
-
+const VimeoMobileArticleVideoPlayer: React.FC<VimeoArticleVideoPlayerProps> = ({ vimeoDetails }) => {
 	return (
 		<PlayerWrapper playerName="youtube-mobile-article-video">
-			<MobileArticleVideoWrapper vimeoDetails={vimeoDetails} topPosition={getTopPosition()} />
+			<MobileArticleVideoWrapper vimeoDetails={vimeoDetails} />
 		</PlayerWrapper>
 	);
 };

--- a/src/youtube/players/YoutubeMobileArticleVideoPlayer.tsx
+++ b/src/youtube/players/YoutubeMobileArticleVideoPlayer.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import YoutubePlayerWrapper from 'youtube/players/shared/YoutubePlayerWrapper';
 import useOnScreen from 'utils/useOnScreen';
 import PlayerWrapper from 'youtube/players/shared/PlayerWrapper';
+import { useMobileArticleVideoContext } from 'contexts/MobileArticleVideoContext';
 
 import clsx from 'clsx';
 
@@ -13,13 +14,10 @@ import MobileYoutubeOffScreenOverlay from './overlays/MobileYoutubeOffScreenOver
 
 interface MobileArticleVideoWrapperProps {
 	youtubeTakeoverDetails: YoutubeTakeOverDetails;
-	topPosition: string;
 }
 
-const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
-	youtubeTakeoverDetails,
-	topPosition,
-}) => {
+const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({ youtubeTakeoverDetails }) => {
+	const { scrollTopPosition } = useMobileArticleVideoContext();
 	const ref = useRef<HTMLDivElement>(null);
 	const onScreen = useOnScreen(ref, '0px', 1);
 	const [dismissed, setDismissed] = useState(false);
@@ -34,7 +32,7 @@ const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
 						: styles.mobileArticleVideoWrapperIsNotScrollPlayer,
 				)}
 				style={{
-					...(isScrollPlayer && { top: topPosition }),
+					...(isScrollPlayer && { top: scrollTopPosition }),
 				}}
 			>
 				<MobileYoutubeOffScreenOverlay dismiss={() => setDismissed(true)} isScrollPlayer={isScrollPlayer} />
@@ -44,31 +42,10 @@ const MobileArticleVideoWrapper: React.FC<MobileArticleVideoWrapperProps> = ({
 	);
 };
 
-interface MobileArticleVideoPlayerProps extends YoutubeArticleVideoPlayerProps {
-	hasPartnerSlot?: boolean;
-	isFullScreen?: boolean;
-}
-
-const YoutubeMobileArticleVideoPlayer: React.FC<MobileArticleVideoPlayerProps> = ({
-	hasPartnerSlot,
-	isFullScreen,
-	youtubeTakeoverDetails,
-}) => {
-	const getTopPosition = () => {
-		if (isFullScreen) {
-			return '0px';
-		}
-
-		if (hasPartnerSlot) {
-			return '75px';
-		}
-
-		return '55px';
-	};
-
+const YoutubeMobileArticleVideoPlayer: React.FC<YoutubeArticleVideoPlayerProps> = ({ youtubeTakeoverDetails }) => {
 	return (
 		<PlayerWrapper playerName="youtube-mobile-article-video">
-			<MobileArticleVideoWrapper youtubeTakeoverDetails={youtubeTakeoverDetails} topPosition={getTopPosition()} />
+			<MobileArticleVideoWrapper youtubeTakeoverDetails={youtubeTakeoverDetails} />
 		</PlayerWrapper>
 	);
 };


### PR DESCRIPTION
* Added new prop for `MobileArticleVideoLoader`: `scrollTopPosition` - a string that is passed as `top` position for the container in scroll mode
* Passed through MobileArticleVideoContext to avoid unnecessary prop passing down 
* Removed unused props `hasPartnerSlot` and `isFullScreen` and commented out tracking code