### PR TITLE
When switching tabs while an ad is playing, do *not* pause the ad playback

### DIFF
--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -112,8 +112,11 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 
 			playerInstance.on(JWEvents.PLAY, ({ playReason, viewable }: JWPlayEvent) => {
 				const dismissed = getDismissed();
-				// Pause the content play when the user closed the mini player playing the ad
 				if (dismissed && viewable === 0 && playReason === 'autostart') {
+					// Pause the content play when the user closed the mini player playing the ad
+					playerInstance.pause();
+					// Pause the content when the user switches tabs
+				} else if (playReason === 'autostart' && document.visibilityState === 'hidden') {
 					playerInstance.pause();
 				}
 			});

--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -104,6 +104,9 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 				// Keep playing the ad when the user closed the mini player
 				if (viewable === 0 && pauseReason === 'external') {
 					playerInstance.play();
+				} else if (document.visibilityState === 'hidden' && pauseReason === undefined) {
+					// Keep the ad playing even when the user switches tabs
+					playerInstance.play();
 				}
 			});
 


### PR DESCRIPTION
https://fandom.atlassian.net/browse/COTECH-654

----------

Related to https://github.com/Wikia/ad-engine/pull/2150 PR.

We want to control the behavior of ads from JWPlayer. In this case, we want the ad to continue playing when the tab is changed.