### PR TITLE
COTECH-1026 Two changes after QA phase

### DIFF
--- a/src/jwplayer/players/shared/JwPlayerWrapper.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapper.tsx
@@ -3,7 +3,7 @@ import { JWPauseEvent, JWPlayerApi, JWPlayEvent, PlaylistItem } from 'jwplayer/t
 import FandomWirewaxPlugin from 'jwplayer/plugins/fandom-wirewax.plugin';
 import { PlayerContext } from 'jwplayer/players/shared/PlayerContext';
 import { JwPlayerWrapperProps } from 'jwplayer/types';
-import { jwPlayerPlaybackTracker, triggerVideoMetric } from 'jwplayer/utils/videoTracking';
+import { jwPlayerPlaybackTracker } from 'jwplayer/utils/videoTracking';
 import { recordAndTrackDifference, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import useBeforeJwpWrapperRendered from 'jwplayer/utils/useBeforeJwpWrapperRendered';
 import JWEvents from 'jwplayer/players/shared/JWEvents';
@@ -90,7 +90,6 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 				VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY,
 				VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_START,
 			);
-			triggerVideoMetric('loaded');
 
 			const registerPlugin = window.jwplayer().registerPlugin;
 			registerPlugin('wirewax', '8.0', FandomWirewaxPlugin);
@@ -144,7 +143,6 @@ const JwPlayerWrapper: React.FC<JwPlayerWrapperProps> = ({
 
 			playerInstance.on(JWEvents.READY, (event) => {
 				recordAndTrackDifference(VIDEO_RECORD_EVENTS.JW_PLAYER_READY, VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY);
-				triggerVideoMetric('ready');
 				// only add the events after the player is ready
 				jwPlayerPlaybackTracker({ event_name: 'video_player_ready' });
 				addBaseTrackingEvents(playerInstance);

--- a/src/jwplayer/players/shared/JwPlayerWrapperWithStrategyRules.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapperWithStrategyRules.tsx
@@ -9,7 +9,7 @@ import {
 } from 'jwplayer/types';
 import { PlayerContext } from 'jwplayer/players/shared/PlayerContext';
 import { JwPlayerWrapperProps } from 'jwplayer/types';
-import { jwPlayerPlaybackTracker, triggerVideoMetric } from 'jwplayer/utils/videoTracking';
+import { jwPlayerPlaybackTracker } from 'jwplayer/utils/videoTracking';
 import { recordAndTrackDifference, STRATEGY_RULES_VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import JWEvents from 'jwplayer/players/shared/JWEvents';
 import addBaseTrackingEvents from 'jwplayer/players/shared/addBaseTrackingEvents';
@@ -76,7 +76,6 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_READY,
 				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY,
 			);
-			triggerVideoMetric('ready');
 			// only add the events after the player is ready
 			jwPlayerPlaybackTracker({ event_name: 'video_player_ready' });
 			addBaseTrackingEvents(playerInstance);
@@ -120,7 +119,6 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 			STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY,
 			STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_START,
 		);
-		triggerVideoMetric('loaded');
 
 		setConfig(config);
 

--- a/src/jwplayer/players/shared/JwPlayerWrapperWithStrategyRules.tsx
+++ b/src/jwplayer/players/shared/JwPlayerWrapperWithStrategyRules.tsx
@@ -10,7 +10,7 @@ import {
 import { PlayerContext } from 'jwplayer/players/shared/PlayerContext';
 import { JwPlayerWrapperProps } from 'jwplayer/types';
 import { jwPlayerPlaybackTracker, triggerVideoMetric } from 'jwplayer/utils/videoTracking';
-import { recordAndTrackDifference, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
+import { recordAndTrackDifference, STRATEGY_RULES_VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import JWEvents from 'jwplayer/players/shared/JWEvents';
 import addBaseTrackingEvents from 'jwplayer/players/shared/addBaseTrackingEvents';
 import useBeforeJwpWrapperRendered from 'jwplayer/utils/useBeforeJwpWrapperRendered';
@@ -60,8 +60,8 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 
 		playerInstance.on(JWEvents.PLAY, ({ playReason, viewable }: JWPlayEvent) => {
 			recordAndTrackDifference(
-				VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_CONTENT_OR_AD,
-				VIDEO_RECORD_EVENTS.JW_PLAYER_READY,
+				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_CONTENT_OR_AD,
+				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_READY,
 			);
 
 			const dismissed = getDismissed();
@@ -72,7 +72,10 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 		});
 
 		playerInstance.on(JWEvents.READY, () => {
-			recordAndTrackDifference(VIDEO_RECORD_EVENTS.JW_PLAYER_READY, VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY);
+			recordAndTrackDifference(
+				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_READY,
+				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY,
+			);
 			triggerVideoMetric('ready');
 			// only add the events after the player is ready
 			jwPlayerPlaybackTracker({ event_name: 'video_player_ready' });
@@ -81,8 +84,8 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 
 		playerInstance.on(JWEvents.AD_IMPRESSION, () => {
 			recordAndTrackDifference(
-				VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_CONTENT_OR_AD,
-				VIDEO_RECORD_EVENTS.JW_PLAYER_READY,
+				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_PLAYING_CONTENT_OR_AD,
+				STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_READY,
 			);
 
 			const newAdIndex = adIndexRef.current + 1;
@@ -114,8 +117,8 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 
 		jwPlayerPlaybackTracker({ event_name: 'video_player_load' });
 		recordAndTrackDifference(
-			VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY,
-			VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_START,
+			STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_READY,
+			STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_START,
 		);
 		triggerVideoMetric('loaded');
 
@@ -154,7 +157,10 @@ const JwPlayerWrapperWithStrategyRules: React.FC<JwPlayerWrapperProps> = ({
 		prerollAdTag,
 	)}`;
 	const onBeforeLoad = () => {
-		recordAndTrackDifference(VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_START, VIDEO_RECORD_EVENTS.FEATURED_VIDEO_INIT);
+		recordAndTrackDifference(
+			STRATEGY_RULES_VIDEO_RECORD_EVENTS.JW_PLAYER_SCRIPTS_LOAD_START,
+			STRATEGY_RULES_VIDEO_RECORD_EVENTS.FEATURED_VIDEO_INIT,
+		);
 		jwPlayerPlaybackTracker({ event_name: 'video_player_start_load' });
 	};
 	const onLoad = () => {

--- a/src/jwplayer/players/shared/addBaseTrackingEvents.ts
+++ b/src/jwplayer/players/shared/addBaseTrackingEvents.ts
@@ -18,7 +18,6 @@ import {
 	jwPlayerAdTracker,
 	jwPlayerContentTracker,
 	singleTrack,
-	triggerVideoMetric,
 } from 'jwplayer/utils/videoTracking';
 import { getVideoStartupTime, recordVideoEvent, VIDEO_RECORD_EVENTS } from 'jwplayer/utils/videoTimingEvents';
 import { getAssetId } from 'jwplayer/utils/globalJWInterface';
@@ -68,7 +67,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 					video_time_to_first_frame: timeToFirstFrame,
 					video_startup_time: getVideoStartupTime(),
 				});
-				triggerVideoMetric('started');
 			}
 		})
 		.on(JWEvents.TIME, (event: OnVideoTimeEventData) => {
@@ -78,7 +76,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 					player_element_id: playerInstance.id,
 					event_name: 'video_content_quartile_25',
 				});
-				triggerVideoMetric('25-percent');
 			}
 
 			if (event.position >= event.duration * 0.5 && singleTrack('jw-player-video-50' + mediaId)) {
@@ -86,7 +83,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 					player_element_id: playerInstance.id,
 					event_name: 'video_content_quartile_50',
 				});
-				triggerVideoMetric('50-percent');
 			}
 
 			if (event.position >= event.duration * 0.75 && singleTrack('jw-player-video-75' + mediaId)) {
@@ -94,7 +90,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 					player_element_id: playerInstance.id,
 					event_name: 'video_content_quartile_75',
 				});
-				triggerVideoMetric('75-percent');
 			}
 
 			// 10s interval events firing
@@ -127,7 +122,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				player_element_id: playerInstance.id,
 				event_name: 'video_content_completed',
 			});
-			triggerVideoMetric('100-percent');
 		})
 		// Controls
 		.on(JWEvents.PAUSE, (event: PausePlayerEventData) => {
@@ -136,7 +130,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 					player_element_id: playerInstance.id,
 					event_name: 'video_pause',
 				});
-				triggerVideoMetric('paused');
 			}
 		})
 		.on(JWEvents.MUTE, (event: MutePlayerEventData) => {
@@ -211,7 +204,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 		// Errors
 		.on(JWEvents.ERROR, (event: OnErrorEventData) => {
 			console.warn(event);
-			triggerVideoMetric('error', event.code.toString());
 
 			jwPlayerPlaybackTracker({
 				player_element_id: playerInstance.id,
@@ -236,7 +228,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				video_ad_is_in_gallery: isInGallery(),
 				...getAdPropsFromAdEvent(event),
 			});
-			triggerVideoMetric('adstarted');
 		})
 		.on(JWEvents.AD_FINISHED, (event: AdEvents) => {
 			jwPlayerAdTracker({
@@ -245,7 +236,6 @@ export default function addBaseTrackingEvents(playerInstance: Player) {
 				video_ad_is_in_gallery: isInGallery(),
 				...getAdPropsFromAdEvent(event),
 			});
-			triggerVideoMetric('adfinished');
 		})
 		.on(JWEvents.AD_TIME, (event: OnAdTimeEventData) => {
 			const mediaId = getAssetId(playerInstance.id);

--- a/src/jwplayer/utils/videoTimingEvents.ts
+++ b/src/jwplayer/utils/videoTimingEvents.ts
@@ -1,14 +1,21 @@
 import { recordOnce, recordMultiple, difference } from '@fandom/tracking-metrics/timing/timings';
 
-const PREFIX = 'jw-player-';
-
 export const VIDEO_RECORD_EVENTS = {
 	FEATURED_VIDEO_INIT: 'featured-video-init',
-	JW_PLAYER_SCRIPTS_LOAD_START: PREFIX + 'scripts-load-start',
-	JW_PLAYER_SCRIPTS_LOAD_READY: PREFIX + 'scripts-load-ready',
-	JW_PLAYER_READY: PREFIX + 'ready',
-	JW_PLAYER_PLAYING_VIDEO_CONTENT: PREFIX + 'playing-initial-video',
-	JW_PLAYER_PLAYING_CONTENT_OR_AD: PREFIX + 'playing-content-or-ad',
+	JW_PLAYER_SCRIPTS_LOAD_START: 'jw-player-scripts-load-start',
+	JW_PLAYER_SCRIPTS_LOAD_READY: 'jw-player-scripts-load-ready',
+	JW_PLAYER_READY: 'jw-player-ready',
+	JW_PLAYER_PLAYING_VIDEO_CONTENT: 'jw-player-playing-initial-video',
+	JW_PLAYER_PLAYING_CONTENT_OR_AD: 'jw-player-playing-content-or-ad',
+};
+
+export const STRATEGY_RULES_VIDEO_RECORD_EVENTS = {
+	FEATURED_VIDEO_INIT: 'featured-video-init',
+	JW_PLAYER_SCRIPTS_LOAD_START: 'jw-sr-player-scripts-load-start',
+	JW_PLAYER_SCRIPTS_LOAD_READY: 'jw-sr-player-scripts-load-ready',
+	JW_PLAYER_READY: 'jw-sr-player-ready',
+	JW_PLAYER_PLAYING_VIDEO_CONTENT: 'jw-sr-player-playing-initial-video',
+	JW_PLAYER_PLAYING_CONTENT_OR_AD: 'jw-sr-player-playing-content-or-ad',
 };
 
 const recordOptions = { sampleRate: 1 };

--- a/src/jwplayer/utils/videoTracking.ts
+++ b/src/jwplayer/utils/videoTracking.ts
@@ -19,7 +19,6 @@ import {
 	getJWQualityManifest,
 } from 'jwplayer/utils/globalJWInterface';
 import getVideoPlayerVersion from 'jwplayer/utils/getVideoPlayerVersion';
-import triggerMetric from '@fandom/tracking-metrics/metrics/metric';
 
 // https://docs.google.com/spreadsheets/d/1jEn61uIP8dYE8KQP3nrMG3nePFArgxrs3Q4lxTcArZQ/edit#gid=1564524057
 export const PROPERTY_NAMES = {
@@ -141,16 +140,4 @@ export function singleTrack(eventName: string) {
 
 	mappings.add(eventName);
 	return true;
-}
-
-/**
- * Additional DW event recording with sampling for engineering usage. This will allow us to make charts and graphs
- * to monitor releases via the realtime and historical tables
- */
-export function triggerVideoMetric(metric: string, label?: string, value = 1, sample = 0.2) {
-	try {
-		triggerMetric(`video-player:${metric}`, value, sample, label ?? metric);
-	} catch (e) {
-		console.warn('VideoMetric Warning for ' + metric);
-	}
 }


### PR DESCRIPTION
1. Different `ga_category` values for JWP with the strategy rules to make it easier and faster query for the results and splitting them by legacy JWP and JWP with the strategy rules.
2. Clean up of some legacy HTTP tracking request we don't need.