### PR TITLE
Mock window.canPlayVideo() so the legacy player example works

### DIFF
--- a/test-jw/src/App.jsx
+++ b/test-jw/src/App.jsx
@@ -21,6 +21,8 @@ const fandomContextTrackingMock = {
 	pvNumberGlobal: 777,
 };
 
+window.canPlayVideo = () => true;
+
 window.fandomContext = {
 	tracking: fandomContextTrackingMock,
 };


### PR DESCRIPTION
Some time ago we've added [a logic that prevents the player from rendering](https://github.com/Wikia/jwplayer-fandom/pull/225/files#diff-cf367bf401e863769d4b4f377f76dc0db9bb734a60cefd8714f680529871af48R55) when `window.canPlayVideo()` doesn't return `true`. It broke our legacy player and this simple line fixes it.

Another possible fix is removing the logic we added back then if we don't need it 🤔 