### PR TITLE
COTECH-1876 Add script to refresh Medal content imported to JWP

### DIFF
--- a/scripts/jwp-imports-create.js
+++ b/scripts/jwp-imports-create.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 const [siteId, jwpApiSecret, dryRun] = process.argv.slice(2);
 
 if (!siteId || !jwpApiSecret) {

--- a/scripts/jwp-media-refresh.js
+++ b/scripts/jwp-media-refresh.js
@@ -136,6 +136,8 @@ async function updateMediaInJWPlayer({ mediaMapping, refreshedClips }) {
 				headers: jwpRequestHeaders,
 				body: JSON.stringify({
 					metadata: {
+						publish_start_date: new Date(refreshedClip.publishedAt).toISOString(),
+						publish_end_date: new Date(refreshedClip.urlsExpireAt).toISOString(),
 						custom_params: {
 							...media.metadata.custom_params,
 							thumbnail: refreshedClip.thumbnailUrl,

--- a/scripts/jwp-media-refresh.js
+++ b/scripts/jwp-media-refresh.js
@@ -1,5 +1,6 @@
 const [siteId, jwpApiSecret, medalApiSecret, dryRun] = process.argv.slice(2);
 const isDryRun = Boolean(dryRun);
+// Useful for rate-limiting requests to prevent "Too Many Requests" errors
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 if (!siteId || !jwpApiSecret || !medalApiSecret) {
@@ -23,6 +24,13 @@ const medalRequestHeaders = {
 	'X-Authentication': medalApiSecret,
 };
 
+/**
+ * Fetches a list of dynamic playlists from the JWP API.
+ *
+ * The request retrieves up to 100 playlists at a time, which is sufficient
+ * as we are handling a fixed number of playlists. Pagination is not required
+ * at this stage.
+ */
 async function fetchDynamicPlaylists() {
 	try {
 		const query = new URLSearchParams({
@@ -75,6 +83,12 @@ async function collectTagsToInclude(playlistIds) {
 	return tags.filter((value, index, arr) => arr.indexOf(value) === index && value !== 'medal-approved');
 }
 
+/**
+ * Fetches media items filtered by the specified tags from the JWP API.
+ *
+ * The request retrieves up to 1000 media items at a time, which is sufficient
+ * for our current needs. Pagination is not required at this stage.
+ */
 async function fetchMediaByTags(tags) {
 	try {
 		const query = new URLSearchParams({

--- a/scripts/jwp-media-refresh.js
+++ b/scripts/jwp-media-refresh.js
@@ -1,0 +1,164 @@
+const [siteId, jwpApiSecret, medalApiSecret, dryRun] = process.argv.slice(2);
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+if (!siteId || !jwpApiSecret || !medalApiSecret) {
+	console.error('Required arguments are missing');
+	console.info(`Usage example:
+		node jwp-media-update.js [site-id] [jwp-api-secret] [medal-api-secret] [[dry-run]]
+	`);
+	process.exit(1);
+}
+
+const jwpApiUrl = `https://api.jwplayer.com/v2/sites/${siteId}`;
+const jwpRequestHeaders = {
+	accept: 'application/json',
+	'content-type': 'application/json',
+	authorization: jwpApiSecret,
+};
+
+const medalApiUrl = `https://api-v2.medal.tv/syndication`;
+const medalRequestHeaders = {
+	accept: 'application/json',
+	'X-Authentication': medalApiSecret,
+};
+
+function fetchDynamicPlaylists() {
+	const query = new URLSearchParams({
+		page: 1,
+		page_length: 100,
+		q: 'playlist_type:dynamic',
+	});
+	console.group('Fetching playlists...');
+	console.debug(query);
+	return fetch(`${jwpApiUrl}/playlists?${query}`, { headers: jwpRequestHeaders })
+		.then((response) => response.json())
+		.then(({ total, playlists }) => {
+			console.log(`Found ${total} dynamic playlists`);
+			return playlists.map((playlist) => playlist.id);
+		})
+		.catch((err) => console.error(err))
+		.finally(() => console.groupEnd());
+}
+
+function fetchDynamicPlaylist(playlistId) {
+	return fetch(`${jwpApiUrl}/playlists/${playlistId}/dynamic_playlist`, { headers: jwpRequestHeaders })
+		.then((response) => response.json())
+		.catch((err) => console.error(err));
+}
+
+async function collectTagsToInclude(playlistIds) {
+	const tags = [];
+	for (const playlistId of playlistIds) {
+		const {
+			metadata: { tag_filter: tagFilter },
+		} = await fetchDynamicPlaylist(playlistId);
+		tags.push(...tagFilter?.include?.values);
+		await delay(1000);
+	}
+	return tags.filter((value, index, arr) => arr.indexOf(value) === index && value !== 'medal-approved');
+}
+
+function fetchMediaByTags(tags) {
+	const query = new URLSearchParams({
+		page: 1,
+		page_length: 1000,
+		q: `tags:(${tags.join(' OR ')})`,
+	});
+	console.group('Fetching media...');
+	console.debug(query);
+	return fetch(`${jwpApiUrl}/media?${query}`, { headers: jwpRequestHeaders })
+		.then((response) => response.json())
+		.then(({ total, media }) => {
+			console.log(`Found ${total ?? 0} media`);
+			return media;
+		})
+		.catch((err) => console.error(err))
+		.finally(() => console.groupEnd());
+}
+
+async function refreshMediaContent(media) {
+	const mapping = media.map((video) => {
+		const contentId = video.metadata.custom_params.import_guid.split('/').filter(Boolean).pop();
+		return { media: video, contentId };
+	});
+
+	const contentIds = mapping.map((item) => item.contentId);
+
+	console.group('Refreshing media content on Medal...');
+	const response = await fetch(`${medalApiUrl}/content/refresh`, {
+		method: 'POST',
+		headers: medalRequestHeaders,
+		body: JSON.stringify({ contentIds }),
+	});
+	const refreshedClips = await response.json();
+	console.log(`Received ${refreshedClips.length} refreshed clips`);
+	console.groupEnd();
+
+	return { mapping, refreshedClips };
+}
+
+async function updateMediaInJWPlayer({ mapping, refreshedClips }) {
+	console.group('Updating media in JWPlayer...');
+	for (const { media, contentId } of mapping) {
+		const refreshedClip = refreshedClips.find((clip) => clip.contentId === contentId);
+		if (!refreshedClip) {
+			console.warn(`No refreshed data available for JW media ${media.id}`);
+			continue;
+		}
+
+		try {
+			const patchResponse = await fetch(`${jwpApiUrl}/media/${media.id}`, {
+				method: 'PATCH',
+				headers: jwpRequestHeaders,
+				body: JSON.stringify({
+					metadata: {
+						custom_params: {
+							...media.metadata.custom_params,
+							'fandom:thumbnail': refreshedClip.thumbnailUrl,
+						},
+					},
+				}),
+			});
+			if (!patchResponse.ok) {
+				console.error(`Error updating media ${media.id}: ${patchResponse.statusText}`);
+				continue;
+			} else {
+				console.log(`JW media ${media.id} - thumbnail updated successfully`);
+			}
+		} catch (error) {
+			console.error(`Error updating media ${media.id}: ${error.message}`);
+			continue;
+		}
+
+		try {
+			const reuploadResponse = await fetch(`${jwpApiUrl}/media/${media.id}/reupload`, {
+				method: 'PUT',
+				headers: jwpRequestHeaders,
+				body: JSON.stringify({
+					upload: {
+						method: 'external',
+						mime_type: 'video/mp4',
+						source_url: refreshedClip.videoUrl,
+					},
+				}),
+			});
+			if (!reuploadResponse.ok) {
+				console.error(`Error reuploading media ${media.id}: ${reuploadResponse.statusText}`);
+			} else {
+				console.log(`JW media ${media.id} - reupload completed successfully`);
+			}
+		} catch (error) {
+			console.error(`Error reuploading media ${media.id}: ${error.message}`);
+		}
+
+		await delay(1000);
+	}
+	console.groupEnd();
+}
+
+fetchDynamicPlaylists()
+	.then(collectTagsToInclude)
+	.then(fetchMediaByTags)
+	.then(refreshMediaContent)
+	.then(updateMediaInJWPlayer)
+	.catch((error) => console.error(error));

--- a/scripts/jwp-media-refresh.js
+++ b/scripts/jwp-media-refresh.js
@@ -138,7 +138,7 @@ async function updateMediaInJWPlayer({ mediaMapping, refreshedClips }) {
 					metadata: {
 						custom_params: {
 							...media.metadata.custom_params,
-							'fandom:thumbnail': refreshedClip.thumbnailUrl,
+							thumbnail: refreshedClip.thumbnailUrl,
 						},
 					},
 				}),


### PR DESCRIPTION
This PR introduces a new script that automates the process of updating media in JWPlayer based on refreshed content from the Medal API. The script performs the following actions:

- Retrieves dynamic playlists from JWPlayer.
- Extracts relevant tags from each playlist to filter media.
- Uses the collected tags to fetch media from JWPlayer.
- Sends a list of content IDs (extracted from the media) to Medal API to retrieve updated media data.
- Updates the JWPlayer media metadata (including the thumbnail, publish start/end dates) and triggers a reupload with the new video URL.

Additionally, the script supports a dry-run mode. When enabled, the script logs the intended updates without making actual changes, allowing for safe testing.

This solution aims to streamline the synchronization process between JWPlayer and Medal content, ensuring that media assets are always up-to-date with minimal manual intervention.