### PR TITLE
chore (SPLAT-352): pin github actions to commit hash

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'npm'
 
       - name: Package size report
-        uses: pkg-size/action@v1
+        uses: pkg-size/action@a637fb0897b6f14f18e776d8c3dbccb34a1ad27b
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a specific commit hash for the `pkg-size/action` dependency instead of a version tag, ensuring more consistent and reproducible builds.
